### PR TITLE
Simplify the implementation of the mikrotik_dns_record import and add acc test

### DIFF
--- a/mikrotik/resource_dns_record.go
+++ b/mikrotik/resource_dns_record.go
@@ -14,7 +14,7 @@ func resourceRecord() *schema.Resource {
 		Update: resourceServerUpdate,
 		Delete: resourceServerDelete,
 		Importer: &schema.ResourceImporter{
-			State: RecordImport,
+			State: schema.ImportStatePassthrough,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -155,17 +155,4 @@ func recordToData(record *client.DnsRecord, d *schema.ResourceData) error {
 	d.Set("address", record.Address)
 	d.Set("ttl", record.Ttl)
 	return nil
-}
-
-func RecordImport(d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
-	name := d.Id()
-	c := m.(client.Mikrotik)
-
-	record, err := c.FindDnsRecord(name)
-
-	if err != nil {
-		return nil, err
-	}
-	recordToData(record, d)
-	return []*schema.ResourceData{d}, nil
 }

--- a/mikrotik/resource_dns_record_test.go
+++ b/mikrotik/resource_dns_record_test.go
@@ -56,7 +56,27 @@ func TestAccXenorchestraDnsRecord_updateAddress(t *testing.T) {
 	})
 }
 
-// TODO: Add a test for importing the resource
+func TestAccXenorchestraDnsRecord_import(t *testing.T) {
+	resourceName := "mikrotik_dns_record.bar"
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckXenorchestraDnsRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsRecord(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDnsRecordExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id")),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
 
 func testAccDnsRecord() string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
I didn't realize that terraform provided an out of the box import implementation if your record only imports with it's ID/name. This uses that implementation and also adds a test for it.