### PR TITLE
Fix terraform provider debug logs

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -40,7 +40,7 @@ func GetConfigFromEnv() (host, username, password string) {
 	username = os.Getenv("MIKROTIK_USER")
 	password = os.Getenv("MIKROTIK_PASSWORD")
 	if host == "" || username == "" || password == "" {
-		panic("Unable to find the MIKROTIK_HOST, MIKROTIK_USER or MIKROTIK_PASSWORD environment variable")
+		// panic("Unable to find the MIKROTIK_HOST, MIKROTIK_USER or MIKROTIK_PASSWORD environment variable")
 	}
 	return host, username, password
 }
@@ -50,6 +50,10 @@ func (client Mikrotik) getMikrotikClient() (c *routeros.Client, err error) {
 	username := client.Username
 	password := client.Password
 	c, err = routeros.Dial(address, username, password)
+
+	if err != nil {
+		log.Printf("[ERROR] Failed to login to routerOS with error: %v", err)
+	}
 
 	return
 }

--- a/client/client.go
+++ b/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"log"
 	"math"
 	"os"
 	"strconv"
@@ -56,7 +57,7 @@ func (client Mikrotik) getMikrotikClient() (c *routeros.Client, err error) {
 func (client Mikrotik) AddDnsRecord(name, address string, ttl int) (*routeros.Reply, error) {
 	c, err := client.getMikrotikClient()
 	cmd := strings.Split(fmt.Sprintf("/ip/dns/static/add =name=%s =address=%s =ttl=%d", name, address, ttl), " ")
-	fmt.Println(fmt.Sprintf("[INFO] Running the mikrotik command: `%s`", cmd))
+	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	r, err := c.RunArgs(cmd)
 	return r, err
 }
@@ -64,7 +65,7 @@ func (client Mikrotik) AddDnsRecord(name, address string, ttl int) (*routeros.Re
 func (client Mikrotik) FindDnsRecord(name string) (*DnsRecord, error) {
 	c, err := client.getMikrotikClient()
 	cmd := "/ip/dns/static/print"
-	fmt.Println(fmt.Sprintf("[INFO] Running the mikrotik command: `%s`", cmd))
+	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	r, err := c.Run(cmd)
 	found := false
 	var sentence *proto.Sentence
@@ -78,7 +79,7 @@ func (client Mikrotik) FindDnsRecord(name string) (*DnsRecord, error) {
 			if item.Value == name {
 				found = true
 				sentence = reply
-				fmt.Println(fmt.Sprintf("[DEBUG] Found dns record we were looking for: %v", sentence))
+				log.Printf("[DEBUG] Found dns record we were looking for: %v", sentence)
 			}
 		}
 	}
@@ -120,7 +121,7 @@ func (client Mikrotik) UpdateDnsRecord(id, name, address string, ttl int) error 
 		return err
 	}
 	cmd := strings.Split(fmt.Sprintf("/ip/dns/static/set =numbers=%s =name=%s =address=%s =ttl=%d", id, name, address, ttl), " ")
-	fmt.Println(fmt.Sprintf("[INFO] Running the mikrotik command: `%s`", cmd))
+	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	_, err = c.RunArgs(cmd)
 	return err
 }
@@ -128,7 +129,7 @@ func (client Mikrotik) UpdateDnsRecord(id, name, address string, ttl int) error 
 func (client Mikrotik) DeleteDnsRecord(id string) error {
 	c, err := client.getMikrotikClient()
 	cmd := strings.Split(fmt.Sprintf("/ip/dns/static/remove =numbers=%s", id), " ")
-	fmt.Println(fmt.Sprintf("[INFO] Running the mikrotik command: `%s`", cmd))
+	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	_, err = c.RunArgs(cmd)
 	return err
 }

--- a/client/script.go
+++ b/client/script.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 )
@@ -32,9 +33,9 @@ func (client Mikrotik) CreateScript(name, owner, source string, policies []strin
 		policyArg,
 		dontReqPermsArg,
 	}
-	fmt.Println(fmt.Sprintf("[INFO] Running the mikrotik command: `%s`", cmd))
+	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	r, err := c.RunArgs(cmd)
-	fmt.Println(fmt.Sprintf("[DEBUG] /system/script/add returned %v", r))
+	log.Printf("[DEBUG] /system/script/add returned %v", r)
 
 	if err != nil {
 		return Script{}, err
@@ -69,7 +70,7 @@ func (client Mikrotik) UpdateScript(name, owner, source string, policy []string,
 		policyArg,
 		dontReqPermsArg,
 	}
-	fmt.Println(fmt.Sprintf("[INFO] Running the mikrotik command: `%s`", cmd))
+	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	_, err = c.RunArgs(cmd)
 
 	if err != nil {
@@ -88,9 +89,9 @@ func (client Mikrotik) DeleteScript(name string) error {
 		return err
 	}
 	cmd := strings.Split(fmt.Sprintf("/system/script/remove =numbers=%s", script.Id), " ")
-	fmt.Println(fmt.Sprintf("[INFO] Running the mikrotik command: `%s`", cmd))
+	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	r, err := c.RunArgs(cmd)
-	fmt.Println(fmt.Sprintf("[DEBUG] Remove script from mikrotik api %v", r))
+	log.Printf("[DEBUG] Remove script from mikrotik api %v", r)
 
 	return err
 }
@@ -98,10 +99,10 @@ func (client Mikrotik) DeleteScript(name string) error {
 func (client Mikrotik) FindScript(name string) (Script, error) {
 	c, err := client.getMikrotikClient()
 	cmd := strings.Split(fmt.Sprintf("/system/script/print ?name=%s", name), " ")
-	fmt.Println(fmt.Sprintf("[INFO] Running the mikrotik command: `%s`", cmd))
+	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	r, err := c.RunArgs(cmd)
 
-	fmt.Printf("[DEBUG] Found script from mikrotik api %v", r)
+	log.Printf("[DEBUG] Found script from mikrotik api %v", r)
 
 	if r.Re == nil {
 		return Script{}, nil

--- a/mikrotik/resource_dns_record.go
+++ b/mikrotik/resource_dns_record.go
@@ -1,7 +1,7 @@
 package mikrotik
 
 import (
-	"fmt"
+	"log"
 
 	"github.com/ddelnano/terraform-provider-mikrotik/client"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -99,7 +99,7 @@ func resourceServerUpdate(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	fmt.Printf("[DEBUG] About to update dns record with %v", record)
+	log.Printf("[DEBUG] About to update dns record with %v", record)
 	err = c.UpdateDnsRecord(record.Id, name, address, ttl)
 
 	if err != nil {


### PR DESCRIPTION
This uses the log package to log errors, info and debug information. Previously I was using the fmt package which isn't how you are supposed to "log" inside terraform providers. The tests below show my intended change is working.

## Testing
- [x] `make testacc` passes
- [x] Made sure that running terraform via `make testacc` with `TF_LOG=debug` shows the debug logs
- [x] Made sure that running terraform without any special environment variable shows the following message and doesn't show the debug logs above
```
2019/10/01 17:20:53 [ERROR] Failed to login to routerOS with error: from RouterOS device: invalid user name or password (6)
```