### PR TITLE
Refactor the DNS code to match the other client return types

### DIFF
--- a/client/dns.go
+++ b/client/dns.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"log"
 	"strings"
-
-	"github.com/go-routeros/routeros"
 )
 
 type DnsRecord struct {
@@ -15,7 +13,7 @@ type DnsRecord struct {
 	Address string
 }
 
-func (client Mikrotik) AddDnsRecord(name, address string, ttl int) (*routeros.Reply, error) {
+func (client Mikrotik) AddDnsRecord(name, address string, ttl int) (*DnsRecord, error) {
 	c, err := client.getMikrotikClient()
 
 	if err != nil {
@@ -24,7 +22,13 @@ func (client Mikrotik) AddDnsRecord(name, address string, ttl int) (*routeros.Re
 	cmd := strings.Split(fmt.Sprintf("/ip/dns/static/add =name=%s =address=%s =ttl=%d", name, address, ttl), " ")
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	r, err := c.RunArgs(cmd)
-	return r, err
+	log.Printf("[DEBUG] /ip/dns/static/add returned %v", r)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return client.FindDnsRecord(name)
 }
 
 func (client Mikrotik) FindDnsRecord(name string) (*DnsRecord, error) {

--- a/mikrotik/resource_dns_record.go
+++ b/mikrotik/resource_dns_record.go
@@ -42,28 +42,11 @@ func resourceServerCreate(d *schema.ResourceData, m interface{}) error {
 
 	c := m.(client.Mikrotik)
 
-	r, err := c.AddDnsRecord(name, address, ttl)
+	record, err := c.AddDnsRecord(name, address, ttl)
 	if err != nil {
 		return err
 	}
 
-	// If API is successful we should only get a single sentence and list back like so
-	// 2019/02/28 20:13:15 !done @ [{`ret` `*14`}]
-	var id string
-	for _, reply := range r.Re {
-		for _, item := range reply.List {
-			if item.Key == ".id" {
-				id = item.Value
-			}
-		}
-	}
-
-	record := &client.DnsRecord{
-		Id:      id,
-		Address: address,
-		Name:    name,
-		Ttl:     ttl,
-	}
 	recordToData(record, d)
 	return nil
 }


### PR DESCRIPTION
## Testing
- [x] `make testacc` passes