### PR TITLE
Unify the error handling for mikrotik client code

### DIFF
--- a/client/dns.go
+++ b/client/dns.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -56,7 +55,7 @@ func (client Mikrotik) FindDnsRecord(name string) (*DnsRecord, error) {
 	}
 
 	if record.Name == "" {
-		return nil, errors.New(fmt.Sprintf("dns record `%s` not found", name))
+		return nil, NewNotFound(fmt.Sprintf("dns record `%s` not found", name))
 	}
 
 	return &record, nil

--- a/client/dns.go
+++ b/client/dns.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -55,7 +56,7 @@ func (client Mikrotik) FindDnsRecord(name string) (*DnsRecord, error) {
 	}
 
 	if record.Name == "" {
-		return nil, nil
+		return nil, errors.New(fmt.Sprintf("dns record `%s` not found", name))
 	}
 
 	return &record, nil

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,0 +1,13 @@
+package client
+
+type NotFound struct {
+	s string
+}
+
+func NewNotFound(text string) error {
+	return &NotFound{text}
+}
+
+func (e *NotFound) Error() string {
+	return e.s
+}

--- a/client/lease.go
+++ b/client/lease.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -86,7 +87,7 @@ func (client Mikrotik) FindDhcpLease(id string) (*DhcpLease, error) {
 	}
 
 	if lease.Id == "" {
-		return nil, nil
+		return nil, errors.New(fmt.Sprintf("dhcp lease `%s` not found", id))
 	}
 
 	return &lease, nil

--- a/client/lease.go
+++ b/client/lease.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -87,7 +86,7 @@ func (client Mikrotik) FindDhcpLease(id string) (*DhcpLease, error) {
 	}
 
 	if lease.Id == "" {
-		return nil, errors.New(fmt.Sprintf("dhcp lease `%s` not found", id))
+		return nil, NewNotFound(fmt.Sprintf("dhcp lease `%s` not found", id))
 	}
 
 	return &lease, nil

--- a/client/lease_test.go
+++ b/client/lease_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -57,5 +58,17 @@ func TestAddLeaseAndDeleteLease(t *testing.T) {
 
 	if err != nil {
 		t.Errorf("Error deleting lease with: %v", err)
+	}
+}
+
+func TestFindDhcpLease_forNonExistantLease(t *testing.T) {
+	c := NewClient(GetConfigFromEnv())
+
+	leaseId := "Invalid id"
+	_, err := c.FindDhcpLease(leaseId)
+
+	expectedErrStr := fmt.Sprintf("dhcp lease `%s` not found", leaseId)
+	if err == nil || err.Error() != expectedErrStr {
+		t.Errorf("client should have received error indicating the following dns record `%s` was not found. Instead error was nil", leaseId)
 	}
 }

--- a/client/scheduler.go
+++ b/client/scheduler.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -29,11 +30,8 @@ func (client Mikrotik) FindScheduler(name string) (*Scheduler, error) {
 		return nil, err
 	}
 
-	if r.Re == nil {
-		return nil, nil
-	}
-	if len(r.Re) > 1 && len(r.Re[0].List) > 1 {
-		return nil, fmt.Errorf("Found more than one result for scheduler with name %s", name)
+	if scheduler.Name == "" {
+		return nil, errors.New(fmt.Sprintf("scheduler `%s` not found", name))
 	}
 	return scheduler, err
 }

--- a/client/scheduler.go
+++ b/client/scheduler.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -31,7 +30,7 @@ func (client Mikrotik) FindScheduler(name string) (*Scheduler, error) {
 	}
 
 	if scheduler.Name == "" {
-		return nil, errors.New(fmt.Sprintf("scheduler `%s` not found", name))
+		return nil, NewNotFound(fmt.Sprintf("scheduler `%s` not found", name))
 	}
 	return scheduler, err
 }

--- a/client/scheduler_test.go
+++ b/client/scheduler_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -38,10 +39,16 @@ func TestCreateDeleteAndFindScheduler(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error deleting a scheduler with: %v", err)
 	}
+}
 
-	scheduler, err = c.FindScheduler(schedulerName)
+func TestFindScheduler_onNonExistantScript(t *testing.T) {
+	c := NewClient(GetConfigFromEnv())
 
-	if err != nil || scheduler != nil {
-		t.Errorf("Scheduler (%v) was not deleted: %v", scheduler, err)
+	name := "scheduler does not exist"
+	_, err := c.FindScheduler(name)
+
+	expectedErrStr := fmt.Sprintf("scheduler `%s` not found", name)
+	if err == nil || err.Error() != expectedErrStr {
+		t.Errorf("client should have received error indicating the following script `%s` was not found. Instead error was nil", name)
 	}
 }

--- a/client/script.go
+++ b/client/script.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -15,11 +16,11 @@ type Script struct {
 	Source                 string
 }
 
-func (s Script) Policy() []string {
+func (s *Script) Policy() []string {
 	return strings.Split(s.PolicyString, ",")
 }
 
-func (client Mikrotik) CreateScript(name, owner, source string, policies []string, dontReqPerms bool) (Script, error) {
+func (client Mikrotik) CreateScript(name, owner, source string, policies []string, dontReqPerms bool) (*Script, error) {
 	c, err := client.getMikrotikClient()
 
 	policiesString := strings.Join(policies, ",")
@@ -41,22 +42,22 @@ func (client Mikrotik) CreateScript(name, owner, source string, policies []strin
 	log.Printf("[DEBUG] /system/script/add returned %v", r)
 
 	if err != nil {
-		return Script{}, err
+		return nil, err
 	}
 	return client.FindScript(name)
 }
 
-func (client Mikrotik) UpdateScript(name, owner, source string, policy []string, dontReqPerms bool) (Script, error) {
+func (client Mikrotik) UpdateScript(name, owner, source string, policy []string, dontReqPerms bool) (*Script, error) {
 	c, err := client.getMikrotikClient()
 
 	if err != nil {
-		return Script{}, err
+		return nil, err
 	}
 
 	script, err := client.FindScript(name)
 
 	if err != nil {
-		return script, err
+		return nil, err
 	}
 
 	policiesString := strings.Join(policy, ",")
@@ -77,7 +78,7 @@ func (client Mikrotik) UpdateScript(name, owner, source string, policy []string,
 	_, err = c.RunArgs(cmd)
 
 	if err != nil {
-		return script, err
+		return nil, err
 	}
 
 	return client.FindScript(name)
@@ -99,26 +100,24 @@ func (client Mikrotik) DeleteScript(name string) error {
 	return err
 }
 
-func (client Mikrotik) FindScript(name string) (Script, error) {
+func (client Mikrotik) FindScript(name string) (*Script, error) {
 	c, err := client.getMikrotikClient()
 	cmd := strings.Split(fmt.Sprintf("/system/script/print ?name=%s", name), " ")
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	r, err := c.RunArgs(cmd)
 
 	log.Printf("[DEBUG] Found script from mikrotik api %v", r)
-	script := Script{}
-	err = Unmarshal(*r, &script)
+	script := &Script{}
+	err = Unmarshal(*r, script)
 
 	if err != nil {
 		return script, err
 	}
 
-	if r.Re == nil {
-		return script, nil
+	if script.Name == "" {
+		return nil, errors.New(fmt.Sprintf("script `%s` not found", name))
 	}
-	if len(r.Re) > 1 && len(r.Re[0].List) > 1 {
-		return script, fmt.Errorf("Found more than one result for script with name %s", name)
-	}
+
 	return script, err
 }
 

--- a/client/script.go
+++ b/client/script.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -115,7 +114,7 @@ func (client Mikrotik) FindScript(name string) (*Script, error) {
 	}
 
 	if script.Name == "" {
-		return nil, errors.New(fmt.Sprintf("script `%s` not found", name))
+		return nil, NewNotFound(fmt.Sprintf("script `%s` not found", name))
 	}
 
 	return script, err

--- a/client/script_test.go
+++ b/client/script_test.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
@@ -48,7 +49,7 @@ func TestCreateScriptAndDeleteScript(t *testing.T) {
 	expectedScript.Id = script.Id
 
 	defer c.DeleteScript(scriptName)
-	if !reflect.DeepEqual(script, expectedScript) {
+	if !reflect.DeepEqual(*script, expectedScript) {
 		t.Errorf("The script does not match what we expected. actual: %v expected: %v", script, expectedScript)
 	}
 
@@ -59,17 +60,14 @@ func TestCreateScriptAndDeleteScript(t *testing.T) {
 	}
 }
 
-func TestFindScriptOnNonExistantScript(t *testing.T) {
+func TestFindScript_onNonExistantScript(t *testing.T) {
 	c := NewClient(GetConfigFromEnv())
 
 	name := "script-not-found"
-	script, err := c.FindScript(name)
+	_, err := c.FindScript(name)
 
-	if err != nil {
-		t.Errorf("Failed to find script `%s` with error: %v", name, err)
-	}
-
-	if script.Name != "" {
-		t.Errorf("Script should have a blank name")
+	expectedErrStr := fmt.Sprintf("script `%s` not found", name)
+	if err == nil || err.Error() != expectedErrStr {
+		t.Errorf("client should have received error indicating the following script `%s` was not found. Instead error was nil", name)
 	}
 }

--- a/mikrotik/dns_test.go
+++ b/mikrotik/dns_test.go
@@ -1,0 +1,21 @@
+package mikrotik
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ddelnano/terraform-provider-mikrotik/client"
+)
+
+func TestFindDnsRecord_nonExistantRecordReturnsError(t *testing.T) {
+
+	c := client.NewClient(client.GetConfigFromEnv())
+
+	recordName := "record.does.not.exist"
+	_, err := c.FindDnsRecord(recordName)
+
+	expectedErrStr := fmt.Sprintf("dns record `%s` not found", recordName)
+	if err == nil || err.Error() != expectedErrStr {
+		t.Errorf("client should have received error indicating the following dns record `%s` was not found. Instead error was nil", recordName)
+	}
+}

--- a/mikrotik/resource_dhcp_lease_test.go
+++ b/mikrotik/resource_dhcp_lease_test.go
@@ -196,7 +196,8 @@ func testAccCheckMikrotikDhcpLeaseDestroyNow(resourceName string) resource.TestC
 
 		dhcpLease, err := c.FindDhcpLease(rs.Primary.ID)
 
-		if err != nil {
+		_, ok = err.(*client.NotFound)
+		if !ok && err != nil {
 			return err
 		}
 
@@ -219,7 +220,8 @@ func testAccCheckMikrotikDhcpLeaseDestroy(s *terraform.State) error {
 
 		dhcpLease, err := c.FindDhcpLease(rs.Primary.ID)
 
-		if err != nil {
+		_, ok := err.(*client.NotFound)
+		if !ok && err != nil {
 			return err
 		}
 

--- a/mikrotik/resource_dns_record.go
+++ b/mikrotik/resource_dns_record.go
@@ -96,22 +96,6 @@ func resourceServerUpdate(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-// !re @ [{`.id` `*2`} {`name` `radarr`} {`address` `192.168.88.254`} {`ttl` `59s`} {`dynamic` `false`} {`regexp` `false`} {`disabled` `false`}]
-// !re @ [{`.id` `*3`} {`name` `sonarr`} {`address` `192.168.88.254`} {`ttl` `59s`} {`dynamic` `false`} {`regexp` `false`} {`disabled` `false`}]
-// !re @ [{`.id` `*4`} {`name` `sabnzbd`} {`address` `192.168.88.254`} {`ttl` `59s`} {`dynamic` `false`} {`regexp` `false`} {`disabled` `false`}]
-// !re @ [{`.id` `*5`} {`name` `kodi`} {`address` `192.168.88.244`} {`ttl` `59s`} {`dynamic` `false`} {`regexp` `false`} {`disabled` `false`}]
-// !re @ [{`.id` `*6`} {`name` `osmc`} {`address` `192.168.88.244`} {`ttl` `59s`} {`dynamic` `false`} {`regexp` `false`} {`disabled` `false`}]
-// !re @ [{`.id` `*7`} {`name` `radarr.internal.ddelnano.com`} {`address` `192.168.88.254`} {`ttl` `1m`} {`dynamic` `false`} {`regexp` `false`} {`disabled` `false`}]
-// !re @ [{`.id` `*8`} {`name` `sonarr.internal.ddelnano.com`} {`address` `192.168.88.254`} {`ttl` `1m`} {`dynamic` `false`} {`regexp` `false`} {`disabled` `false`}]
-// !re @ [{`.id` `*9`} {`name` `sabnzbd.internal.ddelnano.com`} {`address` `192.168.88.254`} {`ttl` `1m`} {`dynamic` `false`} {`regexp` `false`} {`disabled` `false`}]
-// !re @ [{`.id` `*A`} {`name` `router.internal.ddelnano.com`} {`address` `192.168.88.1`} {`ttl` `1m`} {`dynamic` `false`} {`regexp` `false`} {`disabled` `false`}]
-// !re @ [{`.id` `*B`} {`name` `kodi.internal.ddelnano.com`} {`address` `192.168.88.244`} {`ttl` `1m`} {`dynamic` `false`} {`regexp` `false`} {`disabled` `false`}]
-// !re @ [{`.id` `*D`} {`name` `osmc.internal.ddelnano.com`} {`address` `192.168.88.244`} {`ttl` `1m`} {`dynamic` `false`} {`regexp` `false`} {`disabled` `false`}]
-// !re @ [{`.id` `*E`} {`name` `switch.internal.ddelnano.com`} {`address` `192.168.88.90`} {`ttl` `5m`} {`dynamic` `false`} {`regexp` `false`} {`disabled` `false`}]
-// !re @ [{`.id` `*F`} {`name` `xen.internal.ddelnano.com`} {`address` `192.168.88.117`} {`ttl` `5m`} {`dynamic` `false`} {`regexp` `false`} {`disabled` `false`} {`comment` `DNS for the hypervisor`}]
-// !re @ [{`.id` `*10`} {`name` `xoa.internal.ddelnano.com`} {`address` `192.168.88.86`} {`ttl` `5m`} {`dynamic` `false`} {`regexp` `false`} {`disabled` `false`}]
-// !re @ [{`.id` `*15`} {`name` `test`} {`address` `10.0.0.1`} {`ttl` `1d15h20m59s`} {`dynamic` `false`} {`regexp` `false`} {`disabled` `false`}]
-
 func resourceServerDelete(d *schema.ResourceData, m interface{}) error {
 	name := d.Id()
 

--- a/mikrotik/resource_dns_record_test.go
+++ b/mikrotik/resource_dns_record_test.go
@@ -32,6 +32,42 @@ func TestAccMikrotikDnsRecord_create(t *testing.T) {
 	})
 }
 
+func TestAccMikrotikDnsRecord_createAndPlanWithNonExistantRecord(t *testing.T) {
+	resourceName := "mikrotik_dns_record.bar"
+	removeDnsRecord := func() {
+
+		c := client.NewClient(client.GetConfigFromEnv())
+		dns, err := c.FindDnsRecord(originalDnsName)
+
+		if err != nil {
+			t.Fatalf("Error finding the DNS record: %s", err)
+		}
+		err = c.DeleteDnsRecord(dns.Id)
+		if err != nil {
+			t.Fatalf("Error removing the DNS record: %s", err)
+		}
+
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckMikrotikDnsRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsRecord(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDnsRecordExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id")),
+			},
+			{
+				PreConfig:          removeDnsRecord,
+				Config:             testAccDnsRecord(),
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestAccMikrotikDnsRecord_updateAddress(t *testing.T) {
 	resourceName := "mikrotik_dns_record.bar"
 	resource.Test(t, resource.TestCase{

--- a/mikrotik/resource_dns_record_test.go
+++ b/mikrotik/resource_dns_record_test.go
@@ -143,7 +143,8 @@ func testAccCheckMikrotikDnsRecordDestroyNow(resourceName string) resource.TestC
 
 		dnsRecord, err := c.FindDnsRecord(rs.Primary.ID)
 
-		if err != nil {
+		_, ok = err.(*client.NotFound)
+		if !ok && err != nil {
 			return err
 		}
 		err = c.DeleteDnsRecord(dnsRecord.Id)
@@ -165,7 +166,8 @@ func testAccCheckMikrotikDnsRecordDestroy(s *terraform.State) error {
 
 		dnsRecord, err := c.FindDnsRecord(rs.Primary.ID)
 
-		if err != nil {
+		_, ok := err.(*client.NotFound)
+		if !ok && err != nil {
 			return err
 		}
 

--- a/mikrotik/resource_scheduler_test.go
+++ b/mikrotik/resource_scheduler_test.go
@@ -143,7 +143,8 @@ func testAccCheckMikrotikSchedulerDestroy(s *terraform.State) error {
 
 		scheduler, err := c.FindScheduler(rs.Primary.ID)
 
-		if err != nil {
+		_, ok := err.(*client.NotFound)
+		if !ok && err != nil {
 			return err
 		}
 
@@ -169,8 +170,9 @@ func testAccSchedulerExists(resourceName string) resource.TestCheckFunc {
 
 		scheduler, err := c.FindScheduler(rs.Primary.ID)
 
-		if err != nil {
-			return fmt.Errorf("Unable to get the dns record with error: %v", err)
+		_, ok = err.(*client.NotFound)
+		if !ok && err != nil {
+			return fmt.Errorf("Unable to get the scheduler with error: %v", err)
 		}
 
 		if scheduler == nil {

--- a/mikrotik/resource_script.go
+++ b/mikrotik/resource_script.go
@@ -72,7 +72,7 @@ func resourceScriptCreate(d *schema.ResourceData, m interface{}) error {
 	return nil
 }
 
-func scriptToData(s client.Script, d *schema.ResourceData) error {
+func scriptToData(s *client.Script, d *schema.ResourceData) error {
 	d.SetId(s.Name)
 	d.Set("name", s.Name)
 	d.Set("owner", s.Owner)

--- a/mikrotik/resource_script_test.go
+++ b/mikrotik/resource_script_test.go
@@ -235,11 +235,12 @@ func testAccCheckMikrotikScriptDestroy(s *terraform.State) error {
 
 		script, err := c.FindScript(rs.Primary.ID)
 
-		if err != nil {
+		_, ok := err.(*client.NotFound)
+		if !ok && err != nil {
 			return err
 		}
 
-		if script.Name != "" {
+		if script != nil && script.Name != "" {
 			return fmt.Errorf("script (%s) still exists", script.Name)
 		}
 	}
@@ -254,15 +255,16 @@ func testAccScriptExists(resourceName string) resource.TestCheckFunc {
 		}
 
 		if rs.Primary.ID == "" {
-			return fmt.Errorf("mikrotik_dns_record does not exist in the statefile")
+			return fmt.Errorf("mikrotik_script does not exist in the statefile")
 		}
 
 		c := client.NewClient(client.GetConfigFromEnv())
 
 		script, err := c.FindScript(rs.Primary.ID)
 
-		if err != nil {
-			return fmt.Errorf("Unable to get the dns record with error: %v", err)
+		_, ok = err.(*client.NotFound)
+		if !ok && err != nil {
+			return fmt.Errorf("Unable to get the script with error: %v", err)
 		}
 
 		if script.Name == "" {


### PR DESCRIPTION
This is to address #15. The error handling across many of the mikrotik api client was inconsistent so it was possible for a client function to return a nil struct which then causes the terraform code to panic. I was able to test that the current master branch works for creating and destroying dns records so I believe the root of the issue is that the provider code isn't bubbling up the problem before it crashes.

## Testing
- [x] Verify `make testacc` passes
- [x] Verify this fixes #15 (will probably need some help on this)
- [x] Add acceptance test that fails on master but is fixed by this change.
- [ ] Consolidate the acceptance test destroy check code (stretch goal)