### PR TITLE
Cleanup readme and remove unused scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,7 @@
 
 ## Intro
 
-This is a terraform provider for managing resources on your RouterOS device. It currently has support for the following RouterOS concepts:
-- DNS records
-- DHCP leases
-- Scripts
-- Scheduler
-
-## Examples
-
-See the terraform registry [documentation](https://registry.terraform.io/providers/ddelnano/mikrotik/latest/docs) for examples on how to use the resources.
+This is a terraform provider for managing resources on your RouterOS device. To see what resources and data sources are supported, please see the [documentation](https://registry.terraform.io/providers/ddelnano/mikrotik/latest/docs) on the terraform registry.
 
 ## Support
 

--- a/antora.yml
+++ b/antora.yml
@@ -1,6 +1,0 @@
-name: provider-mikrotik
-title: Mikrotik Provider
-version: 'master' 
-start_page: ROOT:index.adoc 
-nav:
-- modules/reference/nav.adoc

--- a/scripts/dist.sh
+++ b/scripts/dist.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-export GOARCH=amd64
-for OS in linux darwin; do
-    export GOOS=$OS
-    file=dist/terraform-provider-mikrotik-${TRAVIS_TAG}-${GOOS}_${GOARCH}
-    go build -o ${file}
-    sha256sum ${file} > "${file}.sha256sum"
-done


### PR DESCRIPTION
This PR does the following things:
1. Remove the ability for the README to become out of date with the current set of resources and data sources. Users should look at the provider documentation to see what is supported
2. Remove a script that was used to build release binaries prior to switching to goreleaser
3. Removed the `antora.yml` which was used before documentation was hosted on the terraform registry