### PR TITLE
Fix comment bug issue 28

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,21 @@
-.PHONY: import testacc dist
+.PHONY: import testacc
 
-TEST ?= ./...
+TIMEOUT ?= 40m
+ifdef TEST
+    TEST := ./... -run $(TEST)
+else
+    TEST := ./...
+endif
+
+ifdef TF_LOG
+    TF_LOG := TF_LOG=$(TF_LOG)
+endif
 
 build:
 	go build -o terraform-provider-mikrotik
 
 clean:
 	rm dist/*
-	terraform-provider-mikrotik
 
 plan: build
 	terraform init
@@ -16,8 +24,5 @@ plan: build
 apply:
 	terraform apply
 
-test:
-	go test $(TEST) -v
-
 testacc:
-	TF_ACC=1 go test $(TEST) -count 1 -v
+	TF_ACC=1 $(TF_LOG) go test $(TEST) -v -count 1 -timeout $(TIMEOUT)

--- a/client/lease.go
+++ b/client/lease.go
@@ -22,7 +22,13 @@ func (client Mikrotik) AddDhcpLease(address, macaddress, name string, blocked st
 	if err != nil {
 		return nil, err
 	}
-	cmd := strings.Split(fmt.Sprintf("/ip/dhcp-server/lease/add =address=%s =mac-address=%s =comment=%q =block-access=%s", address, macaddress, name, blocked), " ")
+	cmd := []string{
+		"/ip/dhcp-server/lease/add",
+		fmt.Sprintf("=address=%s", address),
+		fmt.Sprintf("=mac-address=%s", macaddress),
+		fmt.Sprintf("=comment=%s", name),
+		fmt.Sprintf("=block-access=%s", blocked),
+	}
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	r, err := c.RunArgs(cmd)
 
@@ -100,7 +106,14 @@ func (client Mikrotik) UpdateDhcpLease(id, address, macaddress, comment string, 
 		return nil, err
 	}
 
-	cmd := strings.Split(fmt.Sprintf("/ip/dhcp-server/lease/set =.id=%s =address=%s =mac-address=%s =comment=%q =block-access=%s", id, address, macaddress, comment, blocked), " ")
+	cmd := []string{
+		"/ip/dhcp-server/lease/set",
+		fmt.Sprintf("=.id=%s", id),
+		fmt.Sprintf("=address=%s", address),
+		fmt.Sprintf("=mac-address=%s", macaddress),
+		fmt.Sprintf("=comment=%s", comment),
+		fmt.Sprintf("=block-access=%s", blocked),
+	}
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	_, err = c.RunArgs(cmd)
 

--- a/client/lease.go
+++ b/client/lease.go
@@ -22,7 +22,7 @@ func (client Mikrotik) AddDhcpLease(address, macaddress, name string, blocked st
 	if err != nil {
 		return nil, err
 	}
-	cmd := strings.Split(fmt.Sprintf("/ip/dhcp-server/lease/add =address=%s =mac-address=%s =comment=%s =block-access=%s", address, macaddress, name, blocked), " ")
+	cmd := strings.Split(fmt.Sprintf("/ip/dhcp-server/lease/add =address=%s =mac-address=%s =comment=%q =block-access=%s", address, macaddress, name, blocked), " ")
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	r, err := c.RunArgs(cmd)
 
@@ -100,7 +100,7 @@ func (client Mikrotik) UpdateDhcpLease(id, address, macaddress, comment string, 
 		return nil, err
 	}
 
-	cmd := strings.Split(fmt.Sprintf("/ip/dhcp-server/lease/set =.id=%s =address=%s =mac-address=%s =comment=%s =block-access=%s", id, address, macaddress, comment, blocked), " ")
+	cmd := strings.Split(fmt.Sprintf("/ip/dhcp-server/lease/set =.id=%s =address=%s =mac-address=%s =comment=%q =block-access=%s", id, address, macaddress, comment, blocked), " ")
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	_, err = c.RunArgs(cmd)
 

--- a/mikrotik/resource_dhcp_lease_test.go
+++ b/mikrotik/resource_dhcp_lease_test.go
@@ -11,6 +11,7 @@ import (
 
 var originalIpAddress string = "1.1.1.1"
 var originalMacAddress string = "11:11:11:11:11:11"
+var originalComment string = "multi word comment"
 var updatedIpAddress string = "2.2.2.2"
 var updatedMacAddress string = "22:22:22:22:22:22"
 var updatedBlockAccess string = "true"
@@ -30,6 +31,7 @@ func TestAccMikrotikDhcpLease_create(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "address", originalIpAddress),
 					resource.TestCheckResourceAttr(resourceName, "macaddress", originalMacAddress),
 					resource.TestCheckResourceAttr(resourceName, "dynamic", "false"),
+					resource.TestCheckResourceAttr(resourceName, "comment", originalComment),
 				),
 			},
 		},
@@ -49,6 +51,7 @@ func TestAccMikrotikDhcpLease_updateAddress(t *testing.T) {
 					testAccDhcpLeaseExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "address", originalIpAddress),
 					resource.TestCheckResourceAttr(resourceName, "macaddress", originalMacAddress),
+					resource.TestCheckResourceAttr(resourceName, "comment", originalComment),
 				),
 			},
 			{
@@ -57,6 +60,7 @@ func TestAccMikrotikDhcpLease_updateAddress(t *testing.T) {
 					testAccDhcpLeaseExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "address", updatedIpAddress),
 					resource.TestCheckResourceAttr(resourceName, "macaddress", originalMacAddress),
+					resource.TestCheckResourceAttr(resourceName, "comment", originalComment),
 				),
 			},
 			{
@@ -65,6 +69,7 @@ func TestAccMikrotikDhcpLease_updateAddress(t *testing.T) {
 					testAccDhcpLeaseExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "address", originalIpAddress),
 					resource.TestCheckResourceAttr(resourceName, "macaddress", updatedMacAddress),
+					resource.TestCheckResourceAttr(resourceName, "comment", originalComment),
 				),
 			},
 			{
@@ -74,6 +79,7 @@ func TestAccMikrotikDhcpLease_updateAddress(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "address", originalIpAddress),
 					resource.TestCheckResourceAttr(resourceName, "macaddress", originalMacAddress),
 					resource.TestCheckResourceAttr(resourceName, "blocked", updatedBlockAccess),
+					resource.TestCheckResourceAttr(resourceName, "comment", originalComment),
 				),
 			},
 		},
@@ -123,53 +129,53 @@ func TestAccMikrotikDhcpLease_createDynamicDiff(t *testing.T) {
 func testAccDhcpLease() string {
 	return fmt.Sprintf(`
 resource "mikrotik_dhcp_lease" "bar" {
-    comment = "bar"
     address = "%s"
     macaddress = "%s"
+    comment = "%s"
 }
-`, originalIpAddress, originalMacAddress)
+`, originalIpAddress, originalMacAddress, originalComment)
 }
 
 func testAccDhcpLeaseDynamic() string {
 	return fmt.Sprintf(`
 resource "mikrotik_dhcp_lease" "bar" {
-    comment = "bar"
     address = "%s"
     macaddress = "%s"
+    comment = "%s"
     dynamic = true
 }
-`, originalIpAddress, originalMacAddress)
+`, originalIpAddress, originalMacAddress, originalComment)
 }
 
 func testAccDhcpLeaseUpdatedIpAddress() string {
 	return fmt.Sprintf(`
 resource "mikrotik_dhcp_lease" "bar" {
-    comment = "bar"
     address = "%s"
     macaddress = "%s"
+    comment = "%s"
 }
-`, updatedIpAddress, originalMacAddress)
+`, updatedIpAddress, originalMacAddress, originalComment)
 }
 
 func testAccDhcpLeaseUpdatedMacAddress() string {
 	return fmt.Sprintf(`
 resource "mikrotik_dhcp_lease" "bar" {
-    comment = "bar"
     address = "%s"
     macaddress = "%s"
+    comment = "%s"
 }
-`, originalIpAddress, updatedMacAddress)
+`, originalIpAddress, updatedMacAddress, originalComment)
 }
 
 func testAccDhcpLeaseUpdatedBlockAccess() string {
 	return fmt.Sprintf(`
 resource "mikrotik_dhcp_lease" "bar" {
-    comment = "bar"
     address = "%s"
     macaddress = "%s"
     blocked= "%s"
+    comment = "%s"
 }
-`, originalIpAddress, originalMacAddress, updatedBlockAccess)
+`, originalIpAddress, originalMacAddress, updatedBlockAccess, originalComment)
 }
 
 func testAccDhcpLeaseExists(resourceName string) resource.TestCheckFunc {

--- a/mikrotik/resource_dhcp_lease_test.go
+++ b/mikrotik/resource_dhcp_lease_test.go
@@ -15,6 +15,7 @@ var originalComment string = "multi word comment"
 var updatedIpAddress string = "2.2.2.2"
 var updatedMacAddress string = "22:22:22:22:22:22"
 var updatedBlockAccess string = "true"
+var updatedLeaseComment string = "New multi line comment"
 
 func TestAccMikrotikDhcpLease_create(t *testing.T) {
 	resourceName := "mikrotik_dhcp_lease.bar"
@@ -38,7 +39,7 @@ func TestAccMikrotikDhcpLease_create(t *testing.T) {
 	})
 }
 
-func TestAccMikrotikDhcpLease_updateAddress(t *testing.T) {
+func TestAccMikrotikDhcpLease_updateLease(t *testing.T) {
 	resourceName := "mikrotik_dhcp_lease.bar"
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -61,6 +62,15 @@ func TestAccMikrotikDhcpLease_updateAddress(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "address", updatedIpAddress),
 					resource.TestCheckResourceAttr(resourceName, "macaddress", originalMacAddress),
 					resource.TestCheckResourceAttr(resourceName, "comment", originalComment),
+				),
+			},
+			{
+				Config: testAccDhcpLeaseUpdatedComment(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDhcpLeaseExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "address", originalIpAddress),
+					resource.TestCheckResourceAttr(resourceName, "macaddress", originalMacAddress),
+					resource.TestCheckResourceAttr(resourceName, "comment", updatedLeaseComment),
 				),
 			},
 			{
@@ -176,6 +186,16 @@ resource "mikrotik_dhcp_lease" "bar" {
     comment = "%s"
 }
 `, originalIpAddress, originalMacAddress, updatedBlockAccess, originalComment)
+}
+
+func testAccDhcpLeaseUpdatedComment() string {
+	return fmt.Sprintf(`
+resource "mikrotik_dhcp_lease" "bar" {
+    address = "%s"
+    macaddress = "%s"
+    comment = "%s"
+}
+`, originalIpAddress, originalMacAddress, updatedLeaseComment)
 }
 
 func testAccDhcpLeaseExists(resourceName string) resource.TestCheckFunc {


### PR DESCRIPTION
This fixes #28. There was a problem with how the provider was encoding the string slice. The `strings.Split` function was splitting the comment value into multiple elements which was improperly encoded.

This change fixes this command building problem and add tests for multi word comments and ensures that the provider can correctly update the comment attribute.

## Todo
- [x] `make testacc` passes  
```
ddelnano@ddelnano-desktop:~/go/src/github.com/ddelnano/terraform-provider-mikrotik$ make testacc
TF_ACC=1  go test ./... -v -count 1 -timeout 40m
?       github.com/ddelnano/terraform-provider-mikrotik [no test files]
=== RUN   TestAddBgpInstanceAndDeleteBgpInstance
2021/02/20 22:14:34 [INFO] Running the mikrotik command: `[/routing/bgp/instance/add =name=test-bgp =as=65533 =client-to-client-reflection=yes =disabled=no =ignore-as-path-len=no =redistribute-connected=no =redistribute-ospf=no =redistribute-other-bgp=no =redistribute-rip=no =redistribute-static=no =router-id=172.21.16.2]`
2021/02/20 22:14:34 [DEBUG] /routing/bgp/instance/add returned !done @ [{`ret` `*353`}]
2021/02/20 22:14:34 [INFO] Running the mikrotik command: `[/routing/bgp/instance/print ?name=test-bgp]`
2021/02/20 22:14:34 [DEBUG] Find bgp instance: `[/routing/bgp/instance/print ?name=test-bgp]`
2021/02/20 22:14:34 [INFO] Running the mikrotik command: `[/routing/bgp/instance/print ?name=test-bgp]`
2021/02/20 22:14:34 [DEBUG] Find bgp instance: `[/routing/bgp/instance/print ?name=test-bgp]`
2021/02/20 22:14:34 [INFO] Running the mikrotik command: `[/routing/bgp/instance/remove =numbers=test-bgp]`
2021/02/20 22:14:34 [DEBUG] Remove bgp instance via mikrotik api: !done @ []
--- PASS: TestAddBgpInstanceAndDeleteBgpInstance (0.31s)
=== RUN   TestAddAndUpdateBgpInstanceWithOptionalFieldsAndDeleteBgpInstance
2021/02/20 22:14:34 [INFO] Running the mikrotik command: `[/routing/bgp/instance/add =name=test-bgp =as=65533 =client-to-client-reflection=yes =comment=test-comment =disabled=no =ignore-as-path-len=no =redistribute-connected=no =redistribute-ospf=no =redistribute-other-bgp=no =redistribute-rip=no =redistribute-static=no =router-id=172.21.16.2 =cluster-id=172.21.16.1 =confederation=8]`
2021/02/20 22:14:34 [DEBUG] /routing/bgp/instance/add returned !done @ [{`ret` `*354`}]
2021/02/20 22:14:34 [INFO] Running the mikrotik command: `[/routing/bgp/instance/print ?name=test-bgp]`
2021/02/20 22:14:34 [DEBUG] Find bgp instance: `[/routing/bgp/instance/print ?name=test-bgp]`
2021/02/20 22:14:34 [INFO] Running the mikrotik command: `[/routing/bgp/instance/set =.id=*354 =name=test-bgp =as=65534 =client-to-client-reflection=yes =comment=test-comment =disabled=no =ignore-as-path-len=no =redistribute-connected=no =redistribute-ospf=no =redistribute-other-bgp=no =redistribute-rip=no =redistribute-static=no =router-id=172.21.16.2 =cluster-id=172.21.16.1 =confederation=5]`
2021/02/20 22:14:34 [INFO] Running the mikrotik command: `[/routing/bgp/instance/print ?name=test-bgp]`
2021/02/20 22:14:34 [DEBUG] Find bgp instance: `[/routing/bgp/instance/print ?name=test-bgp]`
2021/02/20 22:14:35 [INFO] Running the mikrotik command: `[/routing/bgp/instance/print ?name=test-bgp]`
2021/02/20 22:14:35 [DEBUG] Find bgp instance: `[/routing/bgp/instance/print ?name=test-bgp]`
2021/02/20 22:14:35 [INFO] Running the mikrotik command: `[/routing/bgp/instance/remove =numbers=test-bgp]`
2021/02/20 22:14:35 [DEBUG] Remove bgp instance via mikrotik api: !done @ []
--- PASS: TestAddAndUpdateBgpInstanceWithOptionalFieldsAndDeleteBgpInstance (0.41s)
=== RUN   TestFindBgpInstance_onNonExistantBgpInstance
2021/02/20 22:14:35 [INFO] Running the mikrotik command: `[/routing/bgp/instance/print ?name=bgp instance does not exist]`
2021/02/20 22:14:35 [DEBUG] Find bgp instance: `[/routing/bgp/instance/print ?name=bgp instance does not exist]`
--- PASS: TestFindBgpInstance_onNonExistantBgpInstance (0.02s)
=== RUN   TestTtlToSeconds
--- PASS: TestTtlToSeconds (0.00s)
=== RUN   TestUnmarshal
--- PASS: TestUnmarshal (0.00s)
=== RUN   TestUnmarshalOnSlices
--- PASS: TestUnmarshalOnSlices (0.00s)
=== RUN   TestUnmarshal_ttlToSeconds
--- PASS: TestUnmarshal_ttlToSeconds (0.00s)
=== RUN   TestMarshal
--- PASS: TestMarshal (0.00s)
=== RUN   TestMarshalStructWithoutTags
--- PASS: TestMarshalStructWithoutTags (0.00s)
=== RUN   TestAddLeaseAndDeleteLease
2021/02/20 22:14:35 [INFO] Running the mikrotik command: `[/ip/dhcp-server/lease/add =address=1.1.1.1 =mac-address=11:11:11:11:11:11 =comment=terraform-acc-test =block-access=false]`
2021/02/20 22:14:35 [DEBUG] Dhcp lease creation response: `!done @ [{`ret` `*50FA`}]`
2021/02/20 22:14:35 [INFO] Running the mikrotik command: `[/ip/dhcp-server/lease/print ?.id=*50FA]`
2021/02/20 22:14:35 [DEBUG] Dhcp lease response: !re @ [{`.id` `*50FA`} {`address` `1.1.1.1`} {`mac-address` `11:11:11:11:11:11`} {`address-lists` ``} {`dhcp-option` ``} {`status` `waiting`} {`last-seen` `never`} {`radius` `false`} {`dynamic` `false`} {`blocked` `false`} {`disabled` `false`} {`comment` `terraform-acc-test`}]
!done @ []
2021/02/20 22:14:35 [INFO] Running the mikrotik command: `[/ip/dhcp-server/lease/print ?.id=*50FA]`
2021/02/20 22:14:35 [DEBUG] Dhcp lease response: !re @ [{`.id` `*50FA`} {`address` `1.1.1.1`} {`mac-address` `11:11:11:11:11:11`} {`address-lists` ``} {`dhcp-option` ``} {`status` `waiting`} {`last-seen` `never`} {`radius` `false`} {`dynamic` `false`} {`blocked` `false`} {`disabled` `false`} {`comment` `terraform-acc-test`}]
!done @ []
2021/02/20 22:14:35 [INFO] Running the mikrotik command: `[/ip/dhcp-server/lease/remove =.id=*50FA]`
--- PASS: TestAddLeaseAndDeleteLease (0.66s)
=== RUN   TestFindDhcpLease_forNonExistantLease
2021/02/20 22:14:35 [INFO] Running the mikrotik command: `[/ip/dhcp-server/lease/print ?.id=Invalid id]`
2021/02/20 22:14:36 [DEBUG] Dhcp lease response: !done @ []
--- PASS: TestFindDhcpLease_forNonExistantLease (0.30s)
=== RUN   TestAddPoolAndDeletePool
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/ip/pool/add =name=testacc =ranges=172.16.0.1-172.16.0.8,172.16.0.10 =comment=terraform-acc-test-pool]`
2021/02/20 22:14:36 [DEBUG] Pool creation response: `!done @ [{`ret` `*6EC`}]`
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/ip/pool/print ?.id=*6EC]`
2021/02/20 22:14:36 [DEBUG] Pool response: !re @ [{`.id` `*6EC`} {`name` `testacc`} {`ranges` `172.16.0.1-172.16.0.8,172.16.0.10`} {`comment` `terraform-acc-test-pool`}]
!done @ []
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/ip/pool/print ?.id=*6EC]`
2021/02/20 22:14:36 [DEBUG] Pool response: !re @ [{`.id` `*6EC`} {`name` `testacc`} {`ranges` `172.16.0.1-172.16.0.8,172.16.0.10`} {`comment` `terraform-acc-test-pool`}]
!done @ []
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/ip/pool/remove =.id=*6EC]`
--- PASS: TestAddPoolAndDeletePool (0.25s)
=== RUN   TestFindPool_forNonExistingPool
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/ip/pool/print ?.id=Invalid id]`
2021/02/20 22:14:36 [DEBUG] Pool response: !done @ []
--- PASS: TestFindPool_forNonExistingPool (0.04s)
=== RUN   TestFindPoolByName_forExistingPool
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/ip/pool/add =name=testacc =ranges=172.16.0.1-172.16.0.8,172.16.0.10 =comment=terraform-acc-test-pool]`
2021/02/20 22:14:36 [DEBUG] Pool creation response: `!done @ [{`ret` `*6ED`}]`
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/ip/pool/print ?.id=*6ED]`
2021/02/20 22:14:36 [DEBUG] Pool response: !re @ [{`.id` `*6ED`} {`name` `testacc`} {`ranges` `172.16.0.1-172.16.0.8,172.16.0.10`} {`comment` `terraform-acc-test-pool`}]
!done @ []
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/ip/pool/print ?name=testacc]`
2021/02/20 22:14:36 [DEBUG] Pool response: !re @ [{`.id` `*6ED`} {`name` `testacc`} {`ranges` `172.16.0.1-172.16.0.8,172.16.0.10`} {`comment` `terraform-acc-test-pool`}]
!done @ []
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/ip/pool/remove =.id=*6ED]`
--- PASS: TestFindPoolByName_forExistingPool (0.16s)
=== RUN   TestFindPoolByName_forNonExistingPool
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/ip/pool/print ?name=Invalid name]`
2021/02/20 22:14:36 [DEBUG] Pool response: !done @ []
--- PASS: TestFindPoolByName_forNonExistingPool (0.02s)
=== RUN   TestCreateDeleteAndFindScheduler
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/system/scheduler/add =name=scheduler =on-event=onevent =interval=0]`
2021/02/20 22:14:36 [DEBUG] /system/scheduler/add returned !done @ [{`ret` `*642`}]
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/system/scheduler/print ?name=scheduler]`
2021/02/20 22:14:36 [DEBUG] Found scheduler from mikrotik api !re @ [{`.id` `*642`} {`name` `scheduler`} {`start-date` `feb/20/2021`} {`start-time` `22:08:47`} {`interval` `0s`} {`on-event` `onevent`} {`owner` `admin`} {`policy` `ftp,reboot,read,write,policy,test,password,sniff,sensitive,romon`} {`run-count` `0`} {`disabled` `false`}]
!done @ []
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/system/scheduler/print ?name=scheduler]`
2021/02/20 22:14:36 [DEBUG] Found scheduler from mikrotik api !re @ [{`.id` `*642`} {`name` `scheduler`} {`start-date` `feb/20/2021`} {`start-time` `22:08:47`} {`interval` `0s`} {`on-event` `onevent`} {`owner` `admin`} {`policy` `ftp,reboot,read,write,policy,test,password,sniff,sensitive,romon`} {`run-count` `0`} {`disabled` `false`}]
!done @ []
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/system/scheduler/remove =numbers=*642]`
2021/02/20 22:14:36 [DEBUG] Remove scheduler from mikrotik api !done @ []
--- PASS: TestCreateDeleteAndFindScheduler (0.18s)
=== RUN   TestFindScheduler_onNonExistantScript
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/system/scheduler/print ?name=scheduler does not exist]`
2021/02/20 22:14:36 [DEBUG] Found scheduler from mikrotik api !done @ []
--- PASS: TestFindScheduler_onNonExistantScript (0.04s)
=== RUN   TestCreateScriptAndDeleteScript
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/system/script/add =name=testing =owner=owner =source=:put testing =policy=ftp,reboot,read,write,policy,test,password,sniff,sensitive,romon =dont-require-permissions=yes]`
2021/02/20 22:14:36 [DEBUG] /system/script/add returned !done @ [{`ret` `*8EE`}]
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/system/script/print ?name=testing]`
2021/02/20 22:14:36 [DEBUG] Found script from mikrotik api !re @ [{`.id` `*8EE`} {`name` `testing`} {`owner` `owner`} {`policy` `ftp,reboot,read,write,policy,test,password,sniff,sensitive,romon`} {`dont-require-permissions` `true`} {`run-count` `0`} {`source` `:put testing`} {`invalid` `false`}]
!done @ []
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/system/script/print ?name=testing]`
2021/02/20 22:14:36 [DEBUG] Found script from mikrotik api !re @ [{`.id` `*8EE`} {`name` `testing`} {`owner` `owner`} {`policy` `ftp,reboot,read,write,policy,test,password,sniff,sensitive,romon`} {`dont-require-permissions` `true`} {`run-count` `0`} {`source` `:put testing`} {`invalid` `false`}]
!done @ []
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/system/script/remove =numbers=*8EE]`
2021/02/20 22:14:36 [DEBUG] Remove script from mikrotik api !done @ []
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/system/script/print ?name=testing]`
2021/02/20 22:14:36 [DEBUG] Found script from mikrotik api !done @ []
--- PASS: TestCreateScriptAndDeleteScript (0.23s)
=== RUN   TestFindScript_onNonExistantScript
2021/02/20 22:14:37 [INFO] Running the mikrotik command: `[/system/script/print ?name=script-not-found]`
2021/02/20 22:14:37 [DEBUG] Found script from mikrotik api !done @ []
--- PASS: TestFindScript_onNonExistantScript (0.03s)
PASS
ok      github.com/ddelnano/terraform-provider-mikrotik/client  2.645s
=== RUN   TestFindDnsRecord_nonExistantRecordReturnsError
2021/02/20 22:14:36 [INFO] Running the mikrotik command: `[/ip/dns/static/print ?name=record.does.not.exist]`
2021/02/20 22:14:36 [DEBUG] Found dns record: !done @ []
--- PASS: TestFindDnsRecord_nonExistantRecordReturnsError (0.04s)
=== RUN   TestAccMikrotikBgpInstance_create
--- PASS: TestAccMikrotikBgpInstance_create (0.41s)
=== RUN   TestAccMikrotikBgpInstance_createAndPlanWithNonExistantBgpInstance
--- PASS: TestAccMikrotikBgpInstance_createAndPlanWithNonExistantBgpInstance (1.54s)
=== RUN   TestAccMikrotikBgpInstance_updateBgpInstance
--- PASS: TestAccMikrotikBgpInstance_updateBgpInstance (3.09s)
=== RUN   TestAccMikrotikBgpInstance_import
--- PASS: TestAccMikrotikBgpInstance_import (0.71s)
=== RUN   TestAccMikrotikDhcpLease_create
--- PASS: TestAccMikrotikDhcpLease_create (0.53s)
=== RUN   TestAccMikrotikDhcpLease_updateLease
--- PASS: TestAccMikrotikDhcpLease_updateLease (3.30s)
=== RUN   TestAccMikrotikDhcpLease_import
--- PASS: TestAccMikrotikDhcpLease_import (1.30s)
=== RUN   TestAccMikrotikDhcpLease_createDynamicDiff
--- PASS: TestAccMikrotikDhcpLease_createDynamicDiff (0.71s)
=== RUN   TestAccMikrotikDnsRecord_create
--- PASS: TestAccMikrotikDnsRecord_create (0.51s)
=== RUN   TestAccMikrotikDnsRecord_createAndPlanWithNonExistantRecord
--- PASS: TestAccMikrotikDnsRecord_createAndPlanWithNonExistantRecord (1.96s)
=== RUN   TestAccMikrotikDnsRecord_updateAddress
--- PASS: TestAccMikrotikDnsRecord_updateAddress (0.48s)
=== RUN   TestAccMikrotikDnsRecord_import
--- PASS: TestAccMikrotikDnsRecord_import (0.29s)
=== RUN   TestAccMikrotikPool_create
--- PASS: TestAccMikrotikPool_create (0.23s)
=== RUN   TestAccMikrotikPool_createAndPlanWithNonExistantPool
--- PASS: TestAccMikrotikPool_createAndPlanWithNonExistantPool (0.47s)
=== RUN   TestAccMikrotikPool_updatePool
--- PASS: TestAccMikrotikPool_updatePool (1.50s)
=== RUN   TestAccMikrotikPool_import
--- PASS: TestAccMikrotikPool_import (1.50s)
=== RUN   TestAccMikrotikScheduler_create
--- PASS: TestAccMikrotikScheduler_create (1.11s)
=== RUN   TestAccMikrotikScheduler_updateInterval
--- PASS: TestAccMikrotikScheduler_updateInterval (2.21s)
=== RUN   TestAccMikrotikScheduler_updatedOnEvent
--- PASS: TestAccMikrotikScheduler_updatedOnEvent (1.72s)
=== RUN   TestAccMikrotikScheduler_import
--- PASS: TestAccMikrotikScheduler_import (1.49s)
=== RUN   TestAccMikrotikScript_create
--- PASS: TestAccMikrotikScript_create (1.25s)
=== RUN   TestAccMikrotikScript_updateSource
--- PASS: TestAccMikrotikScript_updateSource (0.45s)
=== RUN   TestAccMikrotikScript_updateOwner
--- PASS: TestAccMikrotikScript_updateOwner (0.47s)
=== RUN   TestAccMikrotikScript_updateDontReqPerms
--- PASS: TestAccMikrotikScript_updateDontReqPerms (1.15s)
=== RUN   TestAccMikrotikScript_updatePolicies
--- PASS: TestAccMikrotikScript_updatePolicies (1.56s)
=== RUN   TestAccMikrotikScript_import
--- PASS: TestAccMikrotikScript_import (1.15s)
PASS
ok      github.com/ddelnano/terraform-provider-mikrotik/mikrotik        31.162s
```