### PR TITLE
Add more error handling to scheduler and script client

### DIFF
--- a/client/scheduler.go
+++ b/client/scheduler.go
@@ -16,6 +16,11 @@ type Scheduler struct {
 
 func (client Mikrotik) FindScheduler(name string) (*Scheduler, error) {
 	c, err := client.getMikrotikClient()
+
+	if err != nil {
+		return nil, err
+	}
+
 	cmd := []string{"/system/scheduler/print", "?name=" + name}
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	r, err := c.RunArgs(cmd)
@@ -37,6 +42,10 @@ func (client Mikrotik) FindScheduler(name string) (*Scheduler, error) {
 func (client Mikrotik) DeleteScheduler(name string) error {
 	c, err := client.getMikrotikClient()
 
+	if err != nil {
+		return err
+	}
+
 	scheduler, err := client.FindScheduler(name)
 
 	if err != nil {
@@ -52,6 +61,10 @@ func (client Mikrotik) DeleteScheduler(name string) error {
 
 func (client Mikrotik) CreateScheduler(s *Scheduler) (*Scheduler, error) {
 	c, err := client.getMikrotikClient()
+
+	if err != nil {
+		return nil, err
+	}
 
 	cmd := Marshal("/system/scheduler/add", s)
 

--- a/client/script.go
+++ b/client/script.go
@@ -21,6 +21,9 @@ func (s *Script) Policy() []string {
 
 func (client Mikrotik) CreateScript(name, owner, source string, policies []string, dontReqPerms bool) (*Script, error) {
 	c, err := client.getMikrotikClient()
+	if err != nil {
+		return nil, err
+	}
 
 	policiesString := strings.Join(policies, ",")
 	nameArg := fmt.Sprintf("=name=%s", name)
@@ -85,6 +88,9 @@ func (client Mikrotik) UpdateScript(name, owner, source string, policy []string,
 
 func (client Mikrotik) DeleteScript(name string) error {
 	c, err := client.getMikrotikClient()
+	if err != nil {
+		return err
+	}
 
 	script, err := client.FindScript(name)
 
@@ -101,6 +107,10 @@ func (client Mikrotik) DeleteScript(name string) error {
 
 func (client Mikrotik) FindScript(name string) (*Script, error) {
 	c, err := client.getMikrotikClient()
+
+	if err != nil {
+		return nil, err
+	}
 	cmd := []string{"/system/script/print", "?name=" + name}
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	r, err := c.RunArgs(cmd)


### PR DESCRIPTION
This PR adds additional error to aid in debugging #39.

## Todo
- [x] `make testclient` and `make testacc` passes