### PR TITLE
Get CI job passing on RouterOS v7 by skipping bgp related tests that will never pass

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -48,7 +48,7 @@ jobs:
           MIKROTIK_USER: admin
           MIKROTIK_PASSWORD: ''
           TF_ACC: 1
-          LEGACY_BPG_SUPPORT: ${{ matrix.legacy_bgp_support }}
+          LEGACY_BGP_SUPPORT: ${{ matrix.legacy_bgp_support }}
 
       - name: Run client tests
         run: make testclient
@@ -57,7 +57,7 @@ jobs:
           MIKROTIK_USER: admin
           MIKROTIK_PASSWORD: ''
           TF_ACC: 1
-          LEGACY_BPG_SUPPORT: ${{ matrix.legacy_bgp_support }}
+          LEGACY_BGP_SUPPORT: ${{ matrix.legacy_bgp_support }}
 
     services:
       routeros:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,11 +18,13 @@ jobs:
         os: [ubuntu-latest]
         # Test against latest stable release, v6 beta and v7 beta
         routeros: ["6.48.3", "6.49beta54"]
+        legacy_bgp_support: [true]
         include:
           - experimental: true
             go: 1.16
             os: ubuntu-latest
             routeros: "latest"
+            legacy_bgp_support: false
     steps:
       - name: Set up Go
         uses: actions/setup-go@v1
@@ -46,6 +48,16 @@ jobs:
           MIKROTIK_USER: admin
           MIKROTIK_PASSWORD: ''
           TF_ACC: 1
+          LEGACY_BPG_SUPPORT: ${{ matrix.legacy_bgp_support }}
+
+      - name: Run client tests
+        run: cd ../client && go test -v ./...
+        env:
+          MIKROTIK_HOST: 127.0.0.1:8728
+          MIKROTIK_USER: admin
+          MIKROTIK_PASSWORD: ''
+          TF_ACC: 1
+          LEGACY_BPG_SUPPORT: ${{ matrix.legacy_bgp_support }}
 
     services:
       routeros:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -42,7 +42,7 @@ jobs:
         run: go build -v .
 
       - name: Run provider tests
-        run: cd mikrotik && go test -v ./...
+        run: make testacc
         env:
           MIKROTIK_HOST: 127.0.0.1:8728
           MIKROTIK_USER: admin
@@ -51,7 +51,7 @@ jobs:
           LEGACY_BPG_SUPPORT: ${{ matrix.legacy_bgp_support }}
 
       - name: Run client tests
-        run: cd ../client && go test -v ./...
+        run: make testclient
         env:
           MIKROTIK_HOST: 127.0.0.1:8728
           MIKROTIK_USER: admin

--- a/client/bgp_instance.go
+++ b/client/bgp_instance.go
@@ -13,8 +13,10 @@ func (LegacyBgpUnsupported) Error() string {
 }
 
 func legacyBgpUnsupported(err error) bool {
-	if strings.Contains(err.Error(), "no such command prefix") {
-		return true
+	if err != nil {
+		if strings.Contains(err.Error(), "no such command prefix") {
+			return true
+		}
 	}
 	return false
 }

--- a/client/bgp_instance.go
+++ b/client/bgp_instance.go
@@ -50,10 +50,6 @@ func (client Mikrotik) AddBgpInstance(b *BgpInstance) (*BgpInstance, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	if legacyBgpUnsupported(err) {
-		return nil, LegacyBgpUnsupported{}
-	}
 	cmd := Marshal("/routing/bgp/instance/add", b)
 
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
@@ -61,6 +57,9 @@ func (client Mikrotik) AddBgpInstance(b *BgpInstance) (*BgpInstance, error) {
 	log.Printf("[DEBUG] /routing/bgp/instance/add returned %v", r)
 
 	if err != nil {
+		if legacyBgpUnsupported(err) {
+			return nil, LegacyBgpUnsupported{}
+		}
 		return nil, err
 	}
 

--- a/client/bgp_instance_test.go
+++ b/client/bgp_instance_test.go
@@ -27,7 +27,7 @@ var routerID string = "172.21.16.2"
 var routingTable string = ""
 
 func TestAddBgpInstanceAndDeleteBgpInstance(t *testing.T) {
-	SkipBgpIfUnsupported(t)
+	SkipLegacyBgpIfUnsupported(t)
 	c := NewClient(GetConfigFromEnv())
 
 	expectedBgpInstance := &BgpInstance{
@@ -63,7 +63,7 @@ func TestAddBgpInstanceAndDeleteBgpInstance(t *testing.T) {
 }
 
 func TestAddAndUpdateBgpInstanceWithOptionalFieldsAndDeleteBgpInstance(t *testing.T) {
-	SkipBgpIfUnsupported(t)
+	SkipLegacyBgpIfUnsupported(t)
 	c := NewClient(GetConfigFromEnv())
 
 	expectedBgpInstance := &BgpInstance{
@@ -114,7 +114,7 @@ func TestAddAndUpdateBgpInstanceWithOptionalFieldsAndDeleteBgpInstance(t *testin
 }
 
 func TestFindBgpInstance_onNonExistantBgpInstance(t *testing.T) {
-	SkipBgpIfUnsupported(t)
+	SkipLegacyBgpIfUnsupported(t)
 	c := NewClient(GetConfigFromEnv())
 
 	name := "bgp instance does not exist"

--- a/client/bgp_instance_test.go
+++ b/client/bgp_instance_test.go
@@ -27,6 +27,7 @@ var routerID string = "172.21.16.2"
 var routingTable string = ""
 
 func TestAddBgpInstanceAndDeleteBgpInstance(t *testing.T) {
+	SkipBgpIfUnsupported(t)
 	c := NewClient(GetConfigFromEnv())
 
 	expectedBgpInstance := &BgpInstance{
@@ -62,6 +63,7 @@ func TestAddBgpInstanceAndDeleteBgpInstance(t *testing.T) {
 }
 
 func TestAddAndUpdateBgpInstanceWithOptionalFieldsAndDeleteBgpInstance(t *testing.T) {
+	SkipBgpIfUnsupported(t)
 	c := NewClient(GetConfigFromEnv())
 
 	expectedBgpInstance := &BgpInstance{
@@ -112,6 +114,7 @@ func TestAddAndUpdateBgpInstanceWithOptionalFieldsAndDeleteBgpInstance(t *testin
 }
 
 func TestFindBgpInstance_onNonExistantBgpInstance(t *testing.T) {
+	SkipBgpIfUnsupported(t)
 	c := NewClient(GetConfigFromEnv())
 
 	name := "bgp instance does not exist"

--- a/client/bgp_peer.go
+++ b/client/bgp_peer.go
@@ -49,8 +49,10 @@ func (client Mikrotik) AddBgpPeer(b *BgpPeer) (*BgpPeer, error) {
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	r, err := c.RunArgs(cmd)
 	log.Printf("[DEBUG] /routing/bgp/peer/add returned %v", r)
-
 	if err != nil {
+		if legacyBgpUnsupported(err) {
+			return nil, LegacyBgpUnsupported{}
+		}
 		return nil, err
 	}
 
@@ -68,6 +70,9 @@ func (client Mikrotik) FindBgpPeer(name string) (*BgpPeer, error) {
 	r, err := c.RunArgs(cmd)
 
 	if err != nil {
+		if legacyBgpUnsupported(err) {
+			return nil, LegacyBgpUnsupported{}
+		}
 		return nil, err
 	}
 
@@ -101,6 +106,9 @@ func (client Mikrotik) UpdateBgpPeer(b *BgpPeer) (*BgpPeer, error) {
 	_, err = c.RunArgs(cmd)
 
 	if err != nil {
+		if legacyBgpUnsupported(err) {
+			return nil, LegacyBgpUnsupported{}
+		}
 		return nil, err
 	}
 

--- a/client/bgp_peer_test.go
+++ b/client/bgp_peer_test.go
@@ -16,7 +16,7 @@ var holdTime string = "3m"
 var nextHopChoice string = "default"
 
 func TestAddBgpPeerAndDeleteBgpPeer(t *testing.T) {
-	SkipBgpIfUnsupported(t)
+	SkipLegacyBgpIfUnsupported(t)
 	c := NewClient(GetConfigFromEnv())
 
 	instanceName := "peer-test"
@@ -60,7 +60,7 @@ func TestAddBgpPeerAndDeleteBgpPeer(t *testing.T) {
 }
 
 func TestAddAndUpdateBgpPeerWithOptionalFieldsAndDeleteBgpPeer(t *testing.T) {
-	SkipBgpIfUnsupported(t)
+	SkipLegacyBgpIfUnsupported(t)
 	c := NewClient(GetConfigFromEnv())
 
 	instanceName := "peer-update-test"
@@ -123,7 +123,7 @@ func TestAddAndUpdateBgpPeerWithOptionalFieldsAndDeleteBgpPeer(t *testing.T) {
 }
 
 func TestFindBgpPeer_onNonExistantBgpPeer(t *testing.T) {
-	SkipBgpIfUnsupported(t)
+	SkipLegacyBgpIfUnsupported(t)
 	c := NewClient(GetConfigFromEnv())
 
 	name := "bgp peer does not exist"

--- a/client/bgp_peer_test.go
+++ b/client/bgp_peer_test.go
@@ -16,6 +16,7 @@ var holdTime string = "3m"
 var nextHopChoice string = "default"
 
 func TestAddBgpPeerAndDeleteBgpPeer(t *testing.T) {
+	SkipBgpIfUnsupported(t)
 	c := NewClient(GetConfigFromEnv())
 
 	instanceName := "peer-test"
@@ -59,6 +60,7 @@ func TestAddBgpPeerAndDeleteBgpPeer(t *testing.T) {
 }
 
 func TestAddAndUpdateBgpPeerWithOptionalFieldsAndDeleteBgpPeer(t *testing.T) {
+	SkipBgpIfUnsupported(t)
 	c := NewClient(GetConfigFromEnv())
 
 	instanceName := "peer-update-test"
@@ -121,6 +123,7 @@ func TestAddAndUpdateBgpPeerWithOptionalFieldsAndDeleteBgpPeer(t *testing.T) {
 }
 
 func TestFindBgpPeer_onNonExistantBgpPeer(t *testing.T) {
+	SkipBgpIfUnsupported(t)
 	c := NewClient(GetConfigFromEnv())
 
 	name := "bgp peer does not exist"

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -5,8 +5,15 @@ import (
 	"testing"
 )
 
-func SkipBgpIfUnsupported(t *testing.T) {
-	if os.Getenv("LEGACY_BGP_SUPPORT") != "true" {
+func SkipLegacyBgpIfUnsupported(t *testing.T) {
+	if !IsLegacyBgpSupported() {
 		t.Skip()
 	}
+}
+
+func IsLegacyBgpSupported() bool {
+	if os.Getenv("LEGACY_BGP_SUPPORT") == "true" {
+		return true
+	}
+	return false
 }

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -1,0 +1,12 @@
+package client
+
+import (
+	"os"
+	"testing"
+)
+
+func SkipBgpIfUnsupported(t *testing.T) {
+	if os.Getenv("LEGACY_BGP_SUPPORT") != "true" {
+		t.Skip()
+	}
+}

--- a/docs/resources/bgp_instance.md
+++ b/docs/resources/bgp_instance.md
@@ -1,6 +1,8 @@
-# mikrotik_pool
+# mikrotik_bgp_instance
 
 Creates a Mikrotik [BGP Instance](https://wiki.mikrotik.com/wiki/Manual:Routing/BGP#Instance).
+
+This resource will not be supported in RouterOS v7+. Mikrotik has deprecated the underlying commands so future BGP support will need new resources created (See #52 for status of this work).
 
 ## Example Usage
 

--- a/docs/resources/bgp_peer.md
+++ b/docs/resources/bgp_peer.md
@@ -1,6 +1,8 @@
-# mikrotik_pool
+# mikrotik_bgp_peer
 
 Creates a Mikrotik [BGP Peer](https://wiki.mikrotik.com/wiki/Manual:Routing/BGP#Peer).
+
+This resource will not be supported in RouterOS v7+. Mikrotik has deprecated the underlying commands so future BGP support will need new resources created (See #52 for status of this work).
 
 ## Example Usage
 

--- a/mikrotik/resource_bgp_instance.go
+++ b/mikrotik/resource_bgp_instance.go
@@ -118,6 +118,10 @@ func resourceBgpInstanceRead(ctx context.Context, d *schema.ResourceData, m inte
 
 	bgpInstance, err := c.FindBgpInstance(d.Id())
 
+	if _, ok := err.(client.LegacyBgpUnsupported); ok {
+		return diag.FromErr(err)
+	}
+
 	if _, ok := err.(*client.NotFound); ok {
 		d.SetId("")
 		return nil
@@ -130,6 +134,9 @@ func resourceBgpInstanceUpdate(ctx context.Context, d *schema.ResourceData, m in
 	c := m.(*client.Mikrotik)
 
 	currentBgpInstance, err := c.FindBgpInstance(d.Get("name").(string))
+	if _, ok := err.(client.LegacyBgpUnsupported); ok {
+		return diag.FromErr(err)
+	}
 
 	instance := prepareBgpInstance(d)
 	instance.ID = currentBgpInstance.ID
@@ -147,6 +154,9 @@ func resourceBgpInstanceDelete(ctx context.Context, d *schema.ResourceData, m in
 	c := m.(*client.Mikrotik)
 
 	err := c.DeleteBgpInstance(d.Get("name").(string))
+	if _, ok := err.(client.LegacyBgpUnsupported); ok {
+		return diag.FromErr(err)
+	}
 
 	if err != nil {
 		return diag.FromErr(err)

--- a/mikrotik/resource_bgp_instance_test.go
+++ b/mikrotik/resource_bgp_instance_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAccMikrotikBgpInstance_create(t *testing.T) {
+	client.SkipBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-create")
 	routerId := internal.GetNewIpAddr()
 	as := acctest.RandIntRange(1, 65535)
@@ -39,6 +40,7 @@ func TestAccMikrotikBgpInstance_create(t *testing.T) {
 }
 
 func TestAccMikrotikBgpInstance_createAndPlanWithNonExistantBgpInstance(t *testing.T) {
+	client.SkipBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-create_with_plan")
 	routerId := internal.GetNewIpAddr()
 	as := acctest.RandIntRange(1, 65535)
@@ -64,6 +66,7 @@ func TestAccMikrotikBgpInstance_createAndPlanWithNonExistantBgpInstance(t *testi
 }
 
 func TestAccMikrotikBgpInstance_updateBgpInstance(t *testing.T) {
+	client.SkipBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-update")
 	routerId := internal.GetNewIpAddr()
 	updatedRouterId := internal.GetNewIpAddr()
@@ -116,6 +119,7 @@ func TestAccMikrotikBgpInstance_updateBgpInstance(t *testing.T) {
 }
 
 func TestAccMikrotikBgpInstance_import(t *testing.T) {
+	client.SkipBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-import")
 	routerId := internal.GetNewIpAddr()
 	as := acctest.RandIntRange(1, 65535)

--- a/mikrotik/resource_bgp_instance_test.go
+++ b/mikrotik/resource_bgp_instance_test.go
@@ -2,6 +2,7 @@ package mikrotik
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -13,7 +14,7 @@ import (
 )
 
 func TestAccMikrotikBgpInstance_create(t *testing.T) {
-	client.SkipBgpIfUnsupported(t)
+	client.SkipLegacyBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-create")
 	routerId := internal.GetNewIpAddr()
 	as := acctest.RandIntRange(1, 65535)
@@ -39,8 +40,30 @@ func TestAccMikrotikBgpInstance_create(t *testing.T) {
 	})
 }
 
+func TestAccMikrotikBgpInstance_createFailsOnRouterOSv7(t *testing.T) {
+	if client.IsLegacyBgpSupported() {
+		t.Skip()
+	}
+
+	name := acctest.RandomWithPrefix("tf-acc-create")
+	routerId := internal.GetNewIpAddr()
+	as := acctest.RandIntRange(1, 65535)
+
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMikrotikBgpInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccBgpInstance(name, as, routerId),
+				ExpectError: regexp.MustCompile(`Your RouterOS version does not support`),
+			},
+		},
+	})
+}
+
 func TestAccMikrotikBgpInstance_createAndPlanWithNonExistantBgpInstance(t *testing.T) {
-	client.SkipBgpIfUnsupported(t)
+	client.SkipLegacyBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-create_with_plan")
 	routerId := internal.GetNewIpAddr()
 	as := acctest.RandIntRange(1, 65535)
@@ -66,7 +89,7 @@ func TestAccMikrotikBgpInstance_createAndPlanWithNonExistantBgpInstance(t *testi
 }
 
 func TestAccMikrotikBgpInstance_updateBgpInstance(t *testing.T) {
-	client.SkipBgpIfUnsupported(t)
+	client.SkipLegacyBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-update")
 	routerId := internal.GetNewIpAddr()
 	updatedRouterId := internal.GetNewIpAddr()
@@ -119,7 +142,7 @@ func TestAccMikrotikBgpInstance_updateBgpInstance(t *testing.T) {
 }
 
 func TestAccMikrotikBgpInstance_import(t *testing.T) {
-	client.SkipBgpIfUnsupported(t)
+	client.SkipLegacyBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-import")
 	routerId := internal.GetNewIpAddr()
 	as := acctest.RandIntRange(1, 65535)

--- a/mikrotik/resource_bgp_peer_test.go
+++ b/mikrotik/resource_bgp_peer_test.go
@@ -24,7 +24,7 @@ var updatedTTL string = "255"
 var updatedUseBfd string = "true"
 
 func TestAccMikrotikBgpPeer_create(t *testing.T) {
-	client.SkipBgpIfUnsupported(t)
+	client.SkipLegacyBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-create")
 	remoteAs := acctest.RandIntRange(1, 65535)
 	remoteAddress, _ := acctest.RandIpAddress("192.168.0.0/24")
@@ -62,7 +62,7 @@ func TestAccMikrotikBgpPeer_create(t *testing.T) {
 }
 
 func TestAccMikrotikBgpPeer_createAndPlanWithNonExistantBgpPeer(t *testing.T) {
-	client.SkipBgpIfUnsupported(t)
+	client.SkipLegacyBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-create_with_plan")
 	remoteAs := acctest.RandIntRange(1, 65535)
 	remoteAddress, _ := acctest.RandIpAddress("192.168.1.0/24")
@@ -101,7 +101,7 @@ func TestAccMikrotikBgpPeer_createAndPlanWithNonExistantBgpPeer(t *testing.T) {
 }
 
 func TestAccMikrotikBgpPeer_updateBgpPeer(t *testing.T) {
-	client.SkipBgpIfUnsupported(t)
+	client.SkipLegacyBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-update")
 	remoteAs := acctest.RandIntRange(1, 65535)
 	remoteAddress, _ := acctest.RandIpAddress("192.168.3.0/24")
@@ -163,7 +163,7 @@ func TestAccMikrotikBgpPeer_updateBgpPeer(t *testing.T) {
 }
 
 func TestAccMikrotikBgpPeer_import(t *testing.T) {
-	client.SkipBgpIfUnsupported(t)
+	client.SkipLegacyBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-import")
 	remoteAs := acctest.RandIntRange(1, 65535)
 	remoteAddress, _ := acctest.RandIpAddress("192.168.4.0/24")

--- a/mikrotik/resource_bgp_peer_test.go
+++ b/mikrotik/resource_bgp_peer_test.go
@@ -24,6 +24,7 @@ var updatedTTL string = "255"
 var updatedUseBfd string = "true"
 
 func TestAccMikrotikBgpPeer_create(t *testing.T) {
+	client.SkipBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-create")
 	remoteAs := acctest.RandIntRange(1, 65535)
 	remoteAddress, _ := acctest.RandIpAddress("192.168.0.0/24")
@@ -61,6 +62,7 @@ func TestAccMikrotikBgpPeer_create(t *testing.T) {
 }
 
 func TestAccMikrotikBgpPeer_createAndPlanWithNonExistantBgpPeer(t *testing.T) {
+	client.SkipBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-create_with_plan")
 	remoteAs := acctest.RandIntRange(1, 65535)
 	remoteAddress, _ := acctest.RandIpAddress("192.168.1.0/24")
@@ -99,6 +101,7 @@ func TestAccMikrotikBgpPeer_createAndPlanWithNonExistantBgpPeer(t *testing.T) {
 }
 
 func TestAccMikrotikBgpPeer_updateBgpPeer(t *testing.T) {
+	client.SkipBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-update")
 	remoteAs := acctest.RandIntRange(1, 65535)
 	remoteAddress, _ := acctest.RandIpAddress("192.168.3.0/24")
@@ -160,6 +163,7 @@ func TestAccMikrotikBgpPeer_updateBgpPeer(t *testing.T) {
 }
 
 func TestAccMikrotikBgpPeer_import(t *testing.T) {
+	client.SkipBgpIfUnsupported(t)
 	name := acctest.RandomWithPrefix("tf-acc-import")
 	remoteAs := acctest.RandIntRange(1, 65535)
 	remoteAddress, _ := acctest.RandIpAddress("192.168.4.0/24")


### PR DESCRIPTION
RouterOS v7 will not support the commands used by `mikrotik_bgp_peer` and `mikrotik_bgp_instance`. Instead there are new commands that will need their own corresponding resources. Let's get the CI build passing by skipping those resources.