### PR TITLE
Add comment argument to the mikrotik_dns_record resource

### DIFF
--- a/client/dns.go
+++ b/client/dns.go
@@ -10,6 +10,7 @@ type DnsRecord struct {
 	Name    string `mikrotik:"name"`
 	Ttl     int    `mikrotik:"ttl,ttlToSeconds"`
 	Address string `mikrotik:"address"`
+	Comment string `mikrotik:"comment"`
 }
 
 func (client Mikrotik) AddDnsRecord(d *DnsRecord) (*DnsRecord, error) {

--- a/docs/resources/dns_record.md
+++ b/docs/resources/dns_record.md
@@ -16,6 +16,7 @@ resource "mikrotik_dns_record" "record" {
 * name - (Required) The name of the DNS hostname to be created
 * address - (Required) The A record to be returend from the DNS hostname
 * ttl - (Optional) The ttl of the DNS record.
+* comment - (Optional) The comment text associated with the DNS record.
 
 ## Attributes Reference
 

--- a/mikrotik/resource_dns_record.go
+++ b/mikrotik/resource_dns_record.go
@@ -28,6 +28,11 @@ func resourceRecord() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"comment": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "",
+			},
 			"ttl": {
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -128,6 +133,7 @@ func prepareDnsRecord(d *schema.ResourceData) *client.DnsRecord {
 	dnsRecord.Name = d.Get("name").(string)
 	dnsRecord.Ttl = d.Get("ttl").(int)
 	dnsRecord.Address = d.Get("address").(string)
+	dnsRecord.Comment = d.Get("comment").(string)
 
 	return dnsRecord
 }

--- a/mikrotik/resource_dns_record_test.go
+++ b/mikrotik/resource_dns_record_test.go
@@ -96,6 +96,35 @@ func TestAccMikrotikDnsRecord_updateAddress(t *testing.T) {
 	})
 }
 
+func TestAccMikrotikDnsRecord_updateComment(t *testing.T) {
+	dnsName := internal.GetNewDnsName()
+	ipAddr := internal.GetNewIpAddr()
+	comment := "Initial comment"
+	updatedComment := "new comment"
+
+	resourceName := "mikrotik_dns_record.bar"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMikrotikDnsRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsRecordWithComment(dnsName, ipAddr, comment),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDnsRecordExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "comment", comment),
+				),
+			},
+			{
+				Config: testAccDnsRecordWithComment(dnsName, ipAddr, updatedComment),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDnsRecordExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "comment", updatedComment)),
+			},
+		},
+	})
+}
+
 func TestAccMikrotikDnsRecord_import(t *testing.T) {
 	dnsName := internal.GetNewDnsName()
 	ipAddr := internal.GetNewIpAddr()
@@ -129,6 +158,17 @@ resource "mikrotik_dns_record" "bar" {
     ttl = "300"
 }
 `, dnsName, ipAddr)
+}
+
+func testAccDnsRecordWithComment(dnsName, ipAddr, comment string) string {
+	return fmt.Sprintf(`
+resource "mikrotik_dns_record" "bar" {
+    name = "%s"
+    address = "%s"
+    ttl = "300"
+    comment = "%s"
+}
+`, dnsName, ipAddr, comment)
 }
 
 func testAccDnsRecordExists(resourceName string) resource.TestCheckFunc {


### PR DESCRIPTION
## Testing
- [x] New tests pass
- [x] `make testacc` passes