### PR TITLE
fix: improve error handling in mikrotik/resourceRead() functions

### DIFF
--- a/client/bgp_instance.go
+++ b/client/bgp_instance.go
@@ -127,9 +127,11 @@ func (client Mikrotik) UpdateBgpInstance(b *BgpInstance) (*BgpInstance, error) {
 // DeleteBgpInstance Mikrotik resource
 func (client Mikrotik) DeleteBgpInstance(name string) error {
 	c, err := client.getMikrotikClient()
+	if err != nil {
+		return err
+	}
 
 	bgpInstance, err := client.FindBgpInstance(name)
-
 	if err != nil {
 		return err
 	}

--- a/client/bgp_peer.go
+++ b/client/bgp_peer.go
@@ -117,9 +117,11 @@ func (client Mikrotik) UpdateBgpPeer(b *BgpPeer) (*BgpPeer, error) {
 
 func (client Mikrotik) DeleteBgpPeer(name string) error {
 	c, err := client.getMikrotikClient()
+	if err != nil {
+		return err
+	}
 
 	bgpPeer, err := client.FindBgpPeer(name)
-
 	if err != nil {
 		return err
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -215,6 +215,7 @@ func (client *Mikrotik) getMikrotikClient() (*routeros.Client, error) {
 
 	if err != nil {
 		log.Printf("[ERROR] Failed to login to routerOS with error: %v", err)
+		return nil, err
 	}
 
 	client.connection = mikrotikClient

--- a/mikrotik/resource_bgp_instance.go
+++ b/mikrotik/resource_bgp_instance.go
@@ -126,6 +126,9 @@ func resourceBgpInstanceRead(ctx context.Context, d *schema.ResourceData, m inte
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	return bgpInstanceToData(bgpInstance, d)
 }

--- a/mikrotik/resource_bgp_peer.go
+++ b/mikrotik/resource_bgp_peer.go
@@ -164,6 +164,9 @@ func resourceBgpPeerRead(ctx context.Context, d *schema.ResourceData, m interfac
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	return bgpPeerToData(bgpPeer, d)
 }

--- a/mikrotik/resource_dhcp_lease.go
+++ b/mikrotik/resource_dhcp_lease.go
@@ -68,9 +68,12 @@ func resourceLeaseRead(ctx context.Context, d *schema.ResourceData, m interface{
 
 	lease, err := c.FindDhcpLease(d.Id())
 
-	if err != nil {
+	if _, ok := err.(*client.NotFound); ok {
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	if lease == nil {

--- a/mikrotik/resource_dns_record.go
+++ b/mikrotik/resource_dns_record.go
@@ -64,6 +64,9 @@ func resourceServerRead(ctx context.Context, d *schema.ResourceData, m interface
 		d.SetId("")
 		return nil
 	}
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	return recordToData(record, d)
 }

--- a/mikrotik/resource_pool.go
+++ b/mikrotik/resource_pool.go
@@ -53,9 +53,12 @@ func resourcePoolRead(ctx context.Context, d *schema.ResourceData, m interface{}
 
 	pool, err := c.FindPool(d.Id())
 
-	if err != nil {
+	if _, ok := err.(*client.NotFound); ok {
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	return poolToData(pool, d)

--- a/mikrotik/resource_scheduler.go
+++ b/mikrotik/resource_scheduler.go
@@ -61,6 +61,10 @@ func resourceSchedulerRead(ctx context.Context, d *schema.ResourceData, m interf
 	c := m.(*client.Mikrotik)
 
 	scheduler, err := c.FindScheduler(d.Id())
+	if _, ok := err.(*client.NotFound); ok {
+		d.SetId("")
+		return nil
+	}
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/mikrotik/resource_script.go
+++ b/mikrotik/resource_script.go
@@ -101,9 +101,12 @@ func resourceScriptRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	script, err := c.FindScript(d.Id())
 
-	if err != nil {
+	if _, ok := err.(*client.NotFound); ok {
 		d.SetId("")
 		return nil
+	}
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	return scriptToData(script, d)


### PR DESCRIPTION
fixes #63, fixes #65 

Now instead of panic the output will look like:
```sh
mikrotik_pool.pool: Refreshing state... [id=*1]
mikrotik_script.bar: Refreshing state... [id=my_script]
╷
│ Error: from RouterOS device: invalid user name or password (6)
│ 
│   with mikrotik_pool.pool,
│   on main.tf line 16, in resource "mikrotik_pool" "pool":
│   16: resource "mikrotik_pool" "pool" {
│ 
╵
╷
│ Error: from RouterOS device: invalid user name or password (6)
│ 
│   with mikrotik_script.bar,
│   on main.tf line 22, in resource "mikrotik_script" "bar":
│   22: resource "mikrotik_script" "bar" {
```
 