### PR TITLE
fix: handle empty and 1-element replies from RouterOS when unmarshalling single value

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -40,11 +40,12 @@ func Unmarshal(reply routeros.Reply, v interface{}) error {
 	switch elem.Kind() {
 	case reflect.Slice:
 		l := len(reply.Re)
-		if l <= 1 {
-			panic(fmt.Sprintf("Cannot Unmarshal %d sentence(s) into a slice", l))
+		t := elem.Type()
+		if l < 1 {
+			elem.Set(reflect.MakeSlice(t, 0, 0))
+			break
 		}
 
-		t := elem.Type()
 		d := reflect.MakeSlice(t, l, l)
 
 		for i := 0; i < l; i++ {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -98,67 +98,126 @@ func TestUnmarshalOnSlices(t *testing.T) {
 	name := "testing script"
 	owner := "admin"
 	allowed := "true"
-	testStruct := []struct {
+	type testStruct struct {
 		Name          string
 		NotNamedOwner string `mikrotik:"owner"`
 		Allowed       bool
-	}{{}}
-	reply := routeros.Reply{
-		Re: []*proto.Sentence{
-			{
-				Word: "!re",
-				List: []proto.Pair{
+	}
+
+	cases := []struct {
+		name     string
+		reply    routeros.Reply
+		expected []testStruct
+	}{
+		{
+			name: "reply with len > 1",
+			reply: routeros.Reply{
+				Re: []*proto.Sentence{
 					{
-						Key:   "name",
-						Value: name,
+						Word: "!re",
+						List: []proto.Pair{
+							{
+								Key:   "name",
+								Value: name,
+							},
+							{
+								Key:   "owner",
+								Value: owner,
+							},
+							{
+								Key:   "allowed",
+								Value: allowed,
+							},
+						},
 					},
 					{
-						Key:   "owner",
-						Value: owner,
-					},
-					{
-						Key:   "allowed",
-						Value: allowed,
+						Word: "!re",
+						List: []proto.Pair{
+							{
+								Key:   "name",
+								Value: name + " 2",
+							},
+							{
+								Key:   "owner",
+								Value: owner + " 2",
+							},
+							{
+								Key:   "allowed",
+								Value: allowed,
+							},
+						},
 					},
 				},
 			},
-			{
-				Word: "!re",
-				List: []proto.Pair{
-					{
-						Key:   "name",
-						Value: name,
-					},
-					{
-						Key:   "owner",
-						Value: owner,
-					},
-					{
-						Key:   "allowed",
-						Value: allowed,
-					},
+			expected: []testStruct{
+				{
+					Name:          name,
+					NotNamedOwner: owner,
+					Allowed:       true,
+				},
+				{
+					Name:          name + " 2",
+					NotNamedOwner: owner + " 2",
+					Allowed:       true,
 				},
 			},
 		},
+		{
+			name: "reply with single element",
+			reply: routeros.Reply{
+				Re: []*proto.Sentence{
+					{
+						Word: "!re",
+						List: []proto.Pair{
+							{
+								Key:   "name",
+								Value: name,
+							},
+							{
+								Key:   "owner",
+								Value: owner,
+							},
+							{
+								Key:   "allowed",
+								Value: allowed,
+							},
+						},
+					},
+				},
+			},
+			expected: []testStruct{
+				{
+					Name:          name,
+					NotNamedOwner: owner,
+					Allowed:       true,
+				},
+			},
+		},
+		{
+			name: "empty reply",
+			reply: routeros.Reply{
+				Re: []*proto.Sentence{},
+			},
+			expected: []testStruct{},
+		},
 	}
-	err := Unmarshal(reply, &testStruct)
 
-	if err != nil {
-		t.Errorf("Failed to unmarshal with error: %v", err)
-	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var result []testStruct
+			err := Unmarshal(tc.reply, &result)
 
-	if strings.Compare(name, testStruct[0].Name) != 0 {
-		t.Errorf("Failed to unmarshal name '%s' and testStruct.name '%s' should match", name, testStruct[0].Name)
-	}
+			if err != nil {
+				t.Errorf("Failed to unmarshal with error: %v", err)
+			}
 
-	if strings.Compare(owner, testStruct[0].NotNamedOwner) != 0 {
-		t.Errorf("Failed to unmarshal name '%s' and testStruct.name '%s' should match", name, testStruct[0].Name)
-	}
-
-	b, _ := strconv.ParseBool(allowed)
-	if testStruct[0].Allowed != b {
-		t.Errorf("Failed to unmarshal Allowed '%v' and testStruct.Allowed'%v' should match", b, testStruct[0].Allowed)
-
+			if !reflect.DeepEqual(tc.expected, result) {
+				t.Errorf(`unexpected result:
+				want: %#v
+				got: %#v
+				`, tc.expected, result)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
fixes #68

As a side effect, I handled also an empty reply from RouterOS and return empty slice instead of panicing