### PR TITLE
Proposal/generic client resource wrapper

### DIFF
--- a/client/dns.go
+++ b/client/dns.go
@@ -13,7 +13,8 @@ type DnsRecord struct {
 }
 
 var dnsRecordWrapper *resourceWrapper = &resourceWrapper{
-	idField: "name",
+	idField:       "name",
+	idFieldDelete: "numbers",
 	actionsMap: map[string]string{
 		"add":    "/ip/dns/static/add",
 		"find":   "/ip/dns/static/print",
@@ -22,8 +23,8 @@ var dnsRecordWrapper *resourceWrapper = &resourceWrapper{
 		"delete": "/ip/dns/static/remove",
 	},
 	targetStruct:          &DnsRecord{},
-	addIDExtractorFunc:    func(r *routeros.Reply) string { return r.Done.Map["ret"] },
-	recordIDExtractorFunc: func(r interface{}) string { return r.(*DnsRecord).Id },
+	addIDExtractorFunc:    func(_ *routeros.Reply, resource interface{}) string { return resource.(*DnsRecord).Name },
+	recordIDExtractorFunc: func(r interface{}) string { return r.(*DnsRecord).Name },
 }
 
 func (client Mikrotik) AddDnsRecord(d *DnsRecord) (*DnsRecord, error) {

--- a/client/dns_test.go
+++ b/client/dns_test.go
@@ -12,3 +12,23 @@ func TestFindDnsRecord_onNonExistantDnsRecord(t *testing.T) {
 		t.Errorf("Expecting to receive NotFound error for dns record `%s`, instead error was nil.", name)
 	}
 }
+
+func TestAddDnsRecordAndDelete(t *testing.T) {
+	c := NewClient(GetConfigFromEnv())
+
+	r, err := c.AddDnsRecord(&DnsRecord{
+		Name:    "test-record",
+		Address: "192.168.10.22",
+	})
+
+	t.Log(r)
+	if err != nil {
+		t.Error(err)
+	}
+
+	err = c.DeleteDnsRecord(r.Id)
+	if err != nil {
+		t.Error(err)
+	}
+
+}

--- a/client/ip_addr.go
+++ b/client/ip_addr.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"log"
-
 	"github.com/go-routeros/routeros"
 )
 
@@ -21,6 +19,7 @@ var ipAddressWrapper *resourceWrapper = &resourceWrapper{
 	actionsMap: map[string]string{
 		"add":    "/ip/address/add",
 		"find":   "/ip/address/print",
+		"list":   "/ip/address/print",
 		"update": "/ip/address/set",
 		"delete": "/ip/address/remove",
 	},
@@ -40,29 +39,13 @@ func (client Mikrotik) AddIpAddress(addr *IpAddress) (*IpAddress, error) {
 }
 
 func (client Mikrotik) ListIpAddress() ([]IpAddress, error) {
-	c, err := client.getMikrotikClient()
-
-	if err != nil {
-		return nil, err
-	}
-	cmd := []string{"/ip/address/print"}
-	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
-	r, err := c.RunArgs(cmd)
-
-	if err != nil {
-		return nil, err
-	}
-	log.Printf("[DEBUG] found ip address: %v", r)
-
-	ipaddr := []IpAddress{}
-
-	err = Unmarshal(*r, &ipaddr)
-
+	ipAddressWrapper.WithMikrotikClientGetter(client.getMikrotikClient)
+	ipaddr, err := ipAddressWrapper.List()
 	if err != nil {
 		return nil, err
 	}
 
-	return ipaddr, nil
+	return ipaddr.([]IpAddress), nil
 }
 
 func (client Mikrotik) FindIpAddress(id string) (*IpAddress, error) {

--- a/client/ip_addr.go
+++ b/client/ip_addr.go
@@ -27,7 +27,6 @@ var ipAddressWrapper *resourceWrapper = &resourceWrapper{
 	targetStruct:          &IpAddress{},
 	addIDExtractorFunc:    func(r *routeros.Reply) string { return r.Done.Map["ret"] },
 	recordIDExtractorFunc: func(r interface{}) string { return r.(*IpAddress).Id },
-	foundCheckFunc:        func(r interface{}) bool { return r.(*IpAddress).Id != "" },
 }
 
 func (client Mikrotik) AddIpAddress(addr *IpAddress) (*IpAddress, error) {

--- a/client/ip_addr.go
+++ b/client/ip_addr.go
@@ -14,7 +14,8 @@ type IpAddress struct {
 }
 
 var ipAddressWrapper *resourceWrapper = &resourceWrapper{
-	idField: "id",
+	idField:       ".id",
+	idFieldDelete: ".id",
 	actionsMap: map[string]string{
 		"add":    "/ip/address/add",
 		"find":   "/ip/address/print",
@@ -23,7 +24,7 @@ var ipAddressWrapper *resourceWrapper = &resourceWrapper{
 		"delete": "/ip/address/remove",
 	},
 	targetStruct:          &IpAddress{},
-	addIDExtractorFunc:    func(r *routeros.Reply) string { return r.Done.Map["ret"] },
+	addIDExtractorFunc:    func(r *routeros.Reply, _ interface{}) string { return r.Done.Map["ret"] },
 	recordIDExtractorFunc: func(r interface{}) string { return r.(*IpAddress).Id },
 }
 

--- a/client/ip_addr.go
+++ b/client/ip_addr.go
@@ -14,8 +14,7 @@ type IpAddress struct {
 }
 
 var ipAddressWrapper *resourceWrapper = &resourceWrapper{
-	idField:               "id",
-	mikrotikClientGetFunc: nil,
+	idField: "id",
 	actionsMap: map[string]string{
 		"add":    "/ip/address/add",
 		"find":   "/ip/address/print",
@@ -29,9 +28,7 @@ var ipAddressWrapper *resourceWrapper = &resourceWrapper{
 }
 
 func (client Mikrotik) AddIpAddress(addr *IpAddress) (*IpAddress, error) {
-	ipAddressWrapper.WithMikrotikClientGetter(client.getMikrotikClient)
-
-	r, err := ipAddressWrapper.Add(addr)
+	r, err := ipAddressWrapper.Add(addr, client.getMikrotikClient)
 	if err != nil {
 		return nil, err
 	}
@@ -39,8 +36,7 @@ func (client Mikrotik) AddIpAddress(addr *IpAddress) (*IpAddress, error) {
 }
 
 func (client Mikrotik) ListIpAddress() ([]IpAddress, error) {
-	ipAddressWrapper.WithMikrotikClientGetter(client.getMikrotikClient)
-	ipaddr, err := ipAddressWrapper.List()
+	ipaddr, err := ipAddressWrapper.List(client.getMikrotikClient)
 	if err != nil {
 		return nil, err
 	}
@@ -49,8 +45,7 @@ func (client Mikrotik) ListIpAddress() ([]IpAddress, error) {
 }
 
 func (client Mikrotik) FindIpAddress(id string) (*IpAddress, error) {
-	ipAddressWrapper.WithMikrotikClientGetter(client.getMikrotikClient)
-	ipaddr, err := ipAddressWrapper.Find(id)
+	ipaddr, err := ipAddressWrapper.Find(id, client.getMikrotikClient)
 	if err != nil {
 		return nil, err
 	}
@@ -59,8 +54,7 @@ func (client Mikrotik) FindIpAddress(id string) (*IpAddress, error) {
 }
 
 func (client Mikrotik) UpdateIpAddress(addr *IpAddress) (*IpAddress, error) {
-	ipAddressWrapper.WithMikrotikClientGetter(client.getMikrotikClient)
-	ipaddr, err := ipAddressWrapper.Update(addr)
+	ipaddr, err := ipAddressWrapper.Update(addr, client.getMikrotikClient)
 	if err != nil {
 		return nil, err
 	}
@@ -70,6 +64,5 @@ func (client Mikrotik) UpdateIpAddress(addr *IpAddress) (*IpAddress, error) {
 
 func (client Mikrotik) DeleteIpAddress(id string) error {
 	return ipAddressWrapper.
-		WithMikrotikClientGetter(client.getMikrotikClient).
-		Delete(id)
+		Delete(id, client.getMikrotikClient)
 }

--- a/client/lease.go
+++ b/client/lease.go
@@ -15,7 +15,8 @@ type DhcpLease struct {
 }
 
 var dhcpLeaseWrapper *resourceWrapper = &resourceWrapper{
-	idField: "id",
+	idField:       ".id",
+	idFieldDelete: ".id",
 	actionsMap: map[string]string{
 		"add":    "/ip/dhcp-server/lease/add",
 		"find":   "/ip/dhcp-server/lease/print",
@@ -24,7 +25,7 @@ var dhcpLeaseWrapper *resourceWrapper = &resourceWrapper{
 		"delete": "/ip/dhcp-server/lease/remove",
 	},
 	targetStruct:          &DhcpLease{},
-	addIDExtractorFunc:    func(r *routeros.Reply) string { return r.Done.Map["ret"] },
+	addIDExtractorFunc:    func(r *routeros.Reply, _ interface{}) string { return r.Done.Map["ret"] },
 	recordIDExtractorFunc: func(r interface{}) string { return r.(*DhcpLease).Id },
 }
 

--- a/client/lease_test.go
+++ b/client/lease_test.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"fmt"
+	"log"
 	"reflect"
 	"testing"
 )
@@ -62,14 +62,13 @@ func TestAddLeaseAndDeleteLease(t *testing.T) {
 	}
 }
 
-func TestFindDhcpLease_forNonExistantLease(t *testing.T) {
+func TestFindDhcpLease_forNonExistentLease(t *testing.T) {
 	c := NewClient(GetConfigFromEnv())
 
-	leaseId := "Invalid id"
-	_, err := c.FindDhcpLease(leaseId)
-
-	expectedErrStr := fmt.Sprintf("dhcp lease `%s` not found", leaseId)
-	if err == nil || err.Error() != expectedErrStr {
-		t.Errorf("client should have received error indicating the following dns record `%s` was not found. Instead error was nil", leaseId)
+	leaseId := "*123"
+	r, err := c.FindDhcpLease(leaseId)
+	log.Printf("%+#v", r)
+	if _, ok := err.(*NotFound); err == nil || !ok {
+		t.Errorf("expected error %T, got %v", &NotFound{}, err)
 	}
 }

--- a/client/pool.go
+++ b/client/pool.go
@@ -1,8 +1,7 @@
 package client
 
 import (
-	"fmt"
-	"log"
+	"github.com/go-routeros/routeros"
 )
 
 type Pool struct {
@@ -12,140 +11,66 @@ type Pool struct {
 	Comment string `mikrotik:"comment"`
 }
 
+var poolWrapper *resourceWrapper = &resourceWrapper{
+	idField:       ".id",
+	idFieldDelete: ".id",
+	actionsMap: map[string]string{
+		"add":    "/ip/pool/add",
+		"find":   "/ip/pool/print",
+		"list":   "/ip/pool/print",
+		"update": "/ip/pool/set",
+		"delete": "/ip/pool/remove",
+	},
+	targetStruct:          &Pool{},
+	addIDExtractorFunc:    func(r *routeros.Reply, _ interface{}) string { return r.Done.Map["ret"] },
+	recordIDExtractorFunc: func(r interface{}) string { return r.(*Pool).Id },
+}
+
 func (client Mikrotik) AddPool(p *Pool) (*Pool, error) {
-	c, err := client.getMikrotikClient()
-
-	if err != nil {
-		return nil, err
-	}
-	cmd := Marshal("/ip/pool/add", p)
-	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
-	r, err := c.RunArgs(cmd)
-
-	log.Printf("[DEBUG] Pool creation response: `%v`", r)
-
+	r, err := poolWrapper.Add(p, client.getMikrotikClient)
 	if err != nil {
 		return nil, err
 	}
 
-	id := r.Done.Map["ret"]
-
-	return client.FindPool(id)
+	return r.(*Pool), nil
 }
 
 func (client Mikrotik) ListPools() ([]Pool, error) {
-	c, err := client.getMikrotikClient()
-
-	if err != nil {
-		return nil, err
-	}
-	cmd := []string{"/ip/pool/print"}
-	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
-	r, err := c.RunArgs(cmd)
-
-	if err != nil {
-		return nil, err
-	}
-	log.Printf("[DEBUG] Found pools: %v", r)
-
-	pools := []Pool{}
-
-	err = Unmarshal(*r, &pools)
-
+	r, err := poolWrapper.List(client.getMikrotikClient)
 	if err != nil {
 		return nil, err
 	}
 
-	return pools, nil
+	return r.([]Pool), nil
 }
 
 func (client Mikrotik) FindPool(id string) (*Pool, error) {
-	c, err := client.getMikrotikClient()
-
-	if err != nil {
-		return nil, err
-	}
-	cmd := []string{"/ip/pool/print", "?.id=" + id}
-
-	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
-	r, err := c.RunArgs(cmd)
-
-	log.Printf("[DEBUG] Pool response: %v", r)
-
+	r, err := poolWrapper.Find(id, client.getMikrotikClient)
 	if err != nil {
 		return nil, err
 	}
 
-	pool := Pool{}
-	err = Unmarshal(*r, &pool)
-
-	if err != nil {
-		return nil, err
-	}
-	if pool.Id == "" {
-		return nil, NewNotFound(fmt.Sprintf("pool `%s` not found", id))
-	}
-
-	return &pool, nil
+	return r.(*Pool), nil
 }
 
 func (client Mikrotik) FindPoolByName(name string) (*Pool, error) {
-	c, err := client.getMikrotikClient()
-
-	if err != nil {
-		return nil, err
-	}
-	cmd := []string{"/ip/pool/print", "?name=" + name}
-	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
-	r, err := c.RunArgs(cmd)
-
-	log.Printf("[DEBUG] Pool response: %v", r)
-
+	r, err := poolWrapper.findByField("name", name, client.getMikrotikClient)
 	if err != nil {
 		return nil, err
 	}
 
-	pool := Pool{}
-	err = Unmarshal(*r, &pool)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if pool.Name == "" {
-		return nil, NewNotFound(fmt.Sprintf("pool `%s` not found", name))
-	}
-
-	return &pool, nil
+	return r.(*Pool), nil
 }
 
 func (client Mikrotik) UpdatePool(p *Pool) (*Pool, error) {
-	c, err := client.getMikrotikClient()
-
+	r, err := poolWrapper.Update(p, client.getMikrotikClient)
 	if err != nil {
 		return nil, err
 	}
 
-	cmd := Marshal("/ip/pool/set", p)
-	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
-	_, err = c.RunArgs(cmd)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return client.FindPool(p.Id)
+	return r.(*Pool), nil
 }
 
 func (client Mikrotik) DeletePool(id string) error {
-	c, err := client.getMikrotikClient()
-
-	if err != nil {
-		return err
-	}
-
-	cmd := []string{"/ip/pool/remove", "=.id=" + id}
-	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
-	_, err = c.RunArgs(cmd)
-	return err
+	return poolWrapper.Delete(id, client.getMikrotikClient)
 }

--- a/client/resource_wrapper.go
+++ b/client/resource_wrapper.go
@@ -43,7 +43,15 @@ func (rw *resourceWrapper) Add(resource interface{}, clientGetter mikrotikClient
 }
 
 func (rw *resourceWrapper) Find(id string, clientGetter mikrotikClientGetFunc) (interface{}, error) {
-	cmd := []string{rw.actionsMap["find"], "?" + rw.idField + "=" + id}
+	return rw.findByField(rw.idField, id, clientGetter)
+}
+
+func (rw *resourceWrapper) FindByField(field, value string, clientGetter mikrotikClientGetFunc) (interface{}, error) {
+	return rw.findByField(field, value, clientGetter)
+}
+
+func (rw *resourceWrapper) findByField(field, value string, clientGetter mikrotikClientGetFunc) (interface{}, error) {
+	cmd := []string{rw.actionsMap["find"], "?" + field + "=" + value}
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 
 	c, err := clientGetter()
@@ -63,7 +71,7 @@ func (rw *resourceWrapper) Find(id string, clientGetter mikrotikClientGetFunc) (
 		return nil, err
 	}
 	if rw.recordIDExtractorFunc(targetStructInterface) == "" {
-		return nil, NewNotFound(fmt.Sprintf("resource `%s` not found", id))
+		return nil, NewNotFound(fmt.Sprintf("resource with field `%s=%s` not found", field, value))
 	}
 	return targetStructInterface, nil
 }

--- a/client/resource_wrapper.go
+++ b/client/resource_wrapper.go
@@ -20,7 +20,6 @@ type (
 		addIDExtractorFunc    addIDExtractorFunc
 		recordIDExtractorFunc recordIDExtractorFunc
 		targetStruct          interface{}
-		foundCheckFunc        func(r interface{}) bool
 	}
 )
 
@@ -77,7 +76,7 @@ func (rw *resourceWrapper) Find(id string) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !rw.foundCheckFunc(rw.targetStruct) {
+	if rw.recordIDExtractorFunc(rw.targetStruct) == "" {
 		return nil, NewNotFound(fmt.Sprintf("resource `%s` not found", id))
 	}
 	return rw.targetStruct, nil

--- a/client/resource_wrapper.go
+++ b/client/resource_wrapper.go
@@ -1,0 +1,125 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"log"
+
+	"github.com/go-routeros/routeros"
+)
+
+type (
+	addIDExtractorFunc    func(r *routeros.Reply) string
+	recordIDExtractorFunc func(r interface{}) string
+	mikrotikClientGetFunc func() (*routeros.Client, error)
+
+	resourceWrapper struct {
+		idField               string
+		mikrotikClientGetFunc mikrotikClientGetFunc
+		actionsMap            map[string]string
+		addIDExtractorFunc    addIDExtractorFunc
+		recordIDExtractorFunc recordIDExtractorFunc
+		targetStruct          interface{}
+		foundCheckFunc        func(r interface{}) bool
+	}
+)
+
+func newResourceWrapper(mikrotikClientGetFunc mikrotikClientGetFunc, actionsMap map[string]string, idFieldExtractorFunc addIDExtractorFunc) (*resourceWrapper, error) {
+	if mikrotikClientGetFunc == nil {
+		return nil, errors.New("mikrotik client getter can not be nil")
+	}
+
+	return &resourceWrapper{
+		mikrotikClientGetFunc: mikrotikClientGetFunc,
+		actionsMap:            actionsMap,
+		addIDExtractorFunc:    idFieldExtractorFunc,
+	}, nil
+}
+
+func (rw *resourceWrapper) Add(resource interface{}) (interface{}, error) {
+	c, err := rw.mikrotikClientGetFunc()
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := Marshal(rw.actionsMap["add"], resource)
+	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
+	r, err := c.RunArgs(cmd)
+
+	log.Printf("[DEBUG] ip address creation response: `%v`", r)
+
+	if err != nil {
+		return nil, err
+	}
+
+	id := rw.addIDExtractorFunc(r)
+
+	return rw.Find(id)
+}
+
+func (rw *resourceWrapper) Find(id string) (interface{}, error) {
+	cmd := []string{ipAddressWrapper.actionsMap["find"], "?." + rw.idField + "=" + id}
+	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
+
+	c, err := rw.mikrotikClientGetFunc()
+	if err != nil {
+		return nil, err
+	}
+	r, err := c.RunArgs(cmd)
+
+	log.Printf("[DEBUG] ip address response: %v", r)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = Unmarshal(*r, rw.targetStruct)
+	if err != nil {
+		return nil, err
+	}
+	if !rw.foundCheckFunc(rw.targetStruct) {
+		return nil, NewNotFound(fmt.Sprintf("resource `%s` not found", id))
+	}
+	return rw.targetStruct, nil
+}
+
+func (rw *resourceWrapper) Update(resource interface{}) (interface{}, error) {
+	c, err := rw.mikrotikClientGetFunc()
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := Marshal(rw.actionsMap["update"], resource)
+	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
+	_, err = c.RunArgs(cmd)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return rw.Find(rw.recordIDExtractorFunc(resource))
+
+}
+
+func (rw *resourceWrapper) Delete(id string) error {
+	c, err := rw.mikrotikClientGetFunc()
+	if err != nil {
+		return err
+	}
+
+	cmd := []string{rw.actionsMap["delete"], "=." + rw.idField + "=" + id}
+	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
+	_, err = c.RunArgs(cmd)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func (rw *resourceWrapper) WithMikrotikClientGetter(f mikrotikClientGetFunc) *resourceWrapper {
+	rw.mikrotikClientGetFunc = f
+	return rw
+}

--- a/client/resource_wrapper.go
+++ b/client/resource_wrapper.go
@@ -9,12 +9,13 @@ import (
 )
 
 type (
-	addIDExtractorFunc    func(r *routeros.Reply) string
+	addIDExtractorFunc    func(r *routeros.Reply, resource interface{}) string
 	recordIDExtractorFunc func(r interface{}) string
 	mikrotikClientGetFunc func() (*routeros.Client, error)
 
 	resourceWrapper struct {
 		idField               string
+		idFieldDelete         string
 		actionsMap            map[string]string
 		addIDExtractorFunc    addIDExtractorFunc
 		recordIDExtractorFunc recordIDExtractorFunc
@@ -36,13 +37,13 @@ func (rw *resourceWrapper) Add(resource interface{}, clientGetter mikrotikClient
 	}
 	log.Printf("[DEBUG] creation response: `%v`", r)
 
-	id := rw.addIDExtractorFunc(r)
+	id := rw.addIDExtractorFunc(r, resource)
 
 	return rw.Find(id, clientGetter)
 }
 
 func (rw *resourceWrapper) Find(id string, clientGetter mikrotikClientGetFunc) (interface{}, error) {
-	cmd := []string{rw.actionsMap["find"], "?." + rw.idField + "=" + id}
+	cmd := []string{rw.actionsMap["find"], "?" + rw.idField + "=" + id}
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 
 	c, err := clientGetter()
@@ -116,7 +117,7 @@ func (rw *resourceWrapper) Delete(id string, clientGetter mikrotikClientGetFunc)
 		return err
 	}
 
-	cmd := []string{rw.actionsMap["delete"], "=." + rw.idField + "=" + id}
+	cmd := []string{rw.actionsMap["delete"], "=" + rw.idFieldDelete + "=" + id}
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	_, err = c.RunArgs(cmd)
 

--- a/client/resource_wrapper.go
+++ b/client/resource_wrapper.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"reflect"
@@ -23,18 +22,6 @@ type (
 		targetStruct          interface{}
 	}
 )
-
-func newResourceWrapper(mikrotikClientGetFunc mikrotikClientGetFunc, actionsMap map[string]string, idFieldExtractorFunc addIDExtractorFunc) (*resourceWrapper, error) {
-	if mikrotikClientGetFunc == nil {
-		return nil, errors.New("mikrotik client getter can not be nil")
-	}
-
-	return &resourceWrapper{
-		mikrotikClientGetFunc: mikrotikClientGetFunc,
-		actionsMap:            actionsMap,
-		addIDExtractorFunc:    idFieldExtractorFunc,
-	}, nil
-}
 
 func (rw *resourceWrapper) Add(resource interface{}) (interface{}, error) {
 	c, err := rw.mikrotikClientGetFunc()
@@ -58,7 +45,7 @@ func (rw *resourceWrapper) Add(resource interface{}) (interface{}, error) {
 }
 
 func (rw *resourceWrapper) Find(id string) (interface{}, error) {
-	cmd := []string{ipAddressWrapper.actionsMap["find"], "?." + rw.idField + "=" + id}
+	cmd := []string{rw.actionsMap["find"], "?." + rw.idField + "=" + id}
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 
 	c, err := rw.mikrotikClientGetFunc()
@@ -84,7 +71,7 @@ func (rw *resourceWrapper) Find(id string) (interface{}, error) {
 }
 
 func (rw *resourceWrapper) List() (interface{}, error) {
-	cmd := []string{ipAddressWrapper.actionsMap["list"]}
+	cmd := []string{rw.actionsMap["list"]}
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 
 	c, err := rw.mikrotikClientGetFunc()

--- a/client/resource_wrapper_test.go
+++ b/client/resource_wrapper_test.go
@@ -1,0 +1,164 @@
+package client
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/go-routeros/routeros"
+	"github.com/go-routeros/routeros/proto"
+)
+
+func TestNewTargetStruct(t *testing.T) {
+	type targetStruct struct {
+		ID       string `mikrotik:".id"`
+		Name     string `mikrotik:"name"`
+		Value    int    `mikrotik:"value"`
+		Comments string `mikrotik:"comments"`
+		Enabled  bool   `mikrotik:"enabled"`
+	}
+
+	wrapper := resourceWrapper{
+		targetStruct: &targetStruct{},
+	}
+
+	reply := routeros.Reply{
+		Re: []*proto.Sentence{
+			{
+				Word: "!re",
+				List: []proto.Pair{
+					{
+						Key:   ".id",
+						Value: "recordID",
+					},
+					{
+						Key:   "name",
+						Value: "recordName",
+					},
+					{
+						Key:   "value",
+						Value: "42",
+					},
+					{
+						Key:   "enabled",
+						Value: "true",
+					},
+				},
+			},
+		},
+	}
+
+	expectedResult := targetStruct{
+		ID:      "recordID",
+		Name:    "recordName",
+		Value:   42,
+		Enabled: true,
+	}
+
+	newStruct := wrapper.newTargetStruct().Interface()
+	err := Unmarshal(reply, newStruct)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !reflect.DeepEqual(expectedResult, *newStruct.(*targetStruct)) {
+		t.Errorf(`expected and actual results are different:
+				want: %+#v
+
+				got: %+#v`, expectedResult, *newStruct.(*targetStruct))
+	}
+}
+
+func TestNewTargetStructsList(t *testing.T) {
+	type targetStruct struct {
+		ID       string `mikrotik:".id"`
+		Name     string `mikrotik:"name"`
+		Value    int    `mikrotik:"value"`
+		Comments string `mikrotik:"comments"`
+		Enabled  bool   `mikrotik:"enabled"`
+	}
+
+	wrapper := resourceWrapper{
+		targetStruct: &targetStruct{},
+	}
+
+	reply := routeros.Reply{
+		Re: []*proto.Sentence{
+			{
+				Word: "!re",
+				List: []proto.Pair{
+					{
+						Key:   ".id",
+						Value: "id1",
+					},
+					{
+						Key:   "name",
+						Value: "name 1",
+					},
+					{
+						Key:   "value",
+						Value: "42",
+					},
+					{
+						Key:   "enabled",
+						Value: "true",
+					},
+				},
+			},
+			{
+				Word: "!re",
+				List: []proto.Pair{
+					{
+						Key:   ".id",
+						Value: "id2",
+					},
+					{
+						Key:   "name",
+						Value: "name 2",
+					},
+					{
+						Key:   "value",
+						Value: "43",
+					},
+				},
+			},
+		},
+	}
+
+	expectedResult := []targetStruct{
+		{
+			ID:      "id1",
+			Name:    "name 1",
+			Value:   42,
+			Enabled: true,
+		},
+		{
+			ID:      "id2",
+			Name:    "name 2",
+			Value:   43,
+			Enabled: false,
+		},
+	}
+
+	newStructs := *wrapper.newListOfTargetStructs().Interface().(*[]targetStruct)
+	err := Unmarshal(reply, &newStructs)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(expectedResult) != len(newStructs) {
+		t.Fatalf("expected and resulting list have different length: %d != %d", len(expectedResult), len(newStructs))
+	}
+
+	for i := range expectedResult {
+		if !reflect.DeepEqual(expectedResult[i], newStructs[i]) {
+			t.Errorf(`expected and actual element #%d:
+				want: %+#v
+				got: %+#v
+
+				expected list: %+#v
+
+				actual list: %+#v
+				`, i, expectedResult[i], newStructs[i],
+				expectedResult, newStructs,
+			)
+		}
+	}
+}

--- a/client/script.go
+++ b/client/script.go
@@ -62,13 +62,19 @@ func (client Mikrotik) FindScript(name string) (*Script, error) {
 }
 
 func (client Mikrotik) UpdateScript(name, owner, source string, policy []string, dontReqPerms bool) (*Script, error) {
-	return client.updateScript(&Script{
+	r, err := client.FindScript(name)
+	if err != nil {
+		return nil, err
+	}
+	s := &Script{
+		Id:                     r.Id,
 		Name:                   name,
 		Owner:                  owner,
-		Source:                 source,
 		PolicyString:           strings.Join(policy, ","),
 		DontRequirePermissions: dontReqPerms,
-	})
+		Source:                 source,
+	}
+	return client.updateScript(s)
 }
 
 func (client Mikrotik) updateScript(s *Script) (*Script, error) {

--- a/client/script_test.go
+++ b/client/script_test.go
@@ -1,7 +1,7 @@
 package client
 
 import (
-	"fmt"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -34,7 +34,7 @@ func TestCreateScriptAndDeleteScript(t *testing.T) {
 		PolicyString:           strings.Join(scriptPolicies, ","),
 		DontRequirePermissions: scriptDontReqPerms,
 	}
-	script, err := NewClient(GetConfigFromEnv()).CreateScript(
+	script, err := c.CreateScript(
 		scriptName,
 		scriptOwner,
 		scriptSource,
@@ -48,7 +48,6 @@ func TestCreateScriptAndDeleteScript(t *testing.T) {
 
 	expectedScript.Id = script.Id
 
-	defer c.DeleteScript(scriptName)
 	if !reflect.DeepEqual(*script, expectedScript) {
 		t.Errorf("The script does not match what we expected. actual: %v expected: %v", script, expectedScript)
 	}
@@ -66,8 +65,7 @@ func TestFindScript_onNonExistantScript(t *testing.T) {
 	name := "script-not-found"
 	_, err := c.FindScript(name)
 
-	expectedErrStr := fmt.Sprintf("script `%s` not found", name)
-	if err == nil || err.Error() != expectedErrStr {
-		t.Errorf("client should have received error indicating the following script `%s` was not found. Instead error was nil", name)
+	if err == nil || errors.Is(err, &NotFound{}) {
+		t.Errorf("client should have received error %T but got %T", &NotFound{}, err)
 	}
 }


### PR DESCRIPTION
Closes #67 

This PR unifies all `CRUD` operations for `client` resources in the following way:

1. define a `wrapper` with correct values:
```go
var dnsRecordWrapper *resourceWrapper = &resourceWrapper{
	idField:       "name",
	idFieldDelete: "numbers",
	actionsMap: map[string]string{
		"add":    "/ip/dns/static/add",
		"find":   "/ip/dns/static/print",
		"list":   "/ip/dns/static/print",
		"update": "/ip/dns/static/set",
		"delete": "/ip/dns/static/remove",
	},
	targetStruct:          &DnsRecord{},
	addIDExtractorFunc:    func(_ *routeros.Reply, resource interface{}) string { return resource.(*DnsRecord).Name },
	recordIDExtractorFunc: func(r interface{}) string { return r.(*DnsRecord).Name },
}
```

2. call on of the `CRUD` operations on `wrapper` object and use `type assertion` to work with the value:
```go
r, err := dnsRecordWrapper.Add(d, client.getMikrotikClient)
if err != nil {
	return nil, err
}

return r.(*DnsRecord), nil
```

**Known issues**
Currently, the `resourceWrapper` contains only 2 tests.
I have some improvement suggestions for `Mikrotik` struct to make it more testable, but I don't wont to put too much in a single PR (this one is huge anyway)