### PR TITLE
[resource] add 'next-pool' field support to Pool

### DIFF
--- a/client/pool.go
+++ b/client/pool.go
@@ -6,10 +6,11 @@ import (
 )
 
 type Pool struct {
-	Id      string `mikrotik:".id"`
-	Name    string `mikrotik:"name"`
-	Ranges  string `mikrotik:"ranges"`
-	Comment string `mikrotik:"comment"`
+	Id       string `mikrotik:".id"`
+	Name     string `mikrotik:"name"`
+	Ranges   string `mikrotik:"ranges"`
+	NextPool string `mikrotik:"next-pool"`
+	Comment  string `mikrotik:"comment"`
 }
 
 func (client Mikrotik) AddPool(p *Pool) (*Pool, error) {

--- a/docs/resources/pool.md
+++ b/docs/resources/pool.md
@@ -21,6 +21,7 @@ resource "mikrotik_pool" "pool" {
 ### Optional
 
 - `comment` (String) The comment of the IP Pool to be created.
+- `next_pool` (String) The IP pool to pick next address from if current is exhausted.
 
 ### Read-Only
 

--- a/mikrotik/resource_pool_test.go
+++ b/mikrotik/resource_pool_test.go
@@ -194,8 +194,8 @@ func testAccPoolWithNextPool(name, ranges, nextPoolToUse, nextPoolName string) s
 resource "mikrotik_pool" "bar" {
     name = %q
     ranges = %q
-	next_pool = %q
-	depends_on = [mikrotik_pool.next_pool]
+    next_pool = %q
+    depends_on = [mikrotik_pool.next_pool]
 }
 
 resource "mikrotik_pool" "next_pool" {

--- a/mikrotik/resource_pool_test.go
+++ b/mikrotik/resource_pool_test.go
@@ -195,6 +195,7 @@ resource "mikrotik_pool" "bar" {
     name = %q
     ranges = %q
 	next_pool = %q
+	depends_on = [mikrotik_pool.next_pool]
 }
 
 resource "mikrotik_pool" "next_pool" {

--- a/mikrotik/resource_pool_test.go
+++ b/mikrotik/resource_pool_test.go
@@ -34,6 +34,40 @@ func TestAccMikrotikPool_create(t *testing.T) {
 	})
 }
 
+func TestAccMikrotikPool_createNextPool(t *testing.T) {
+	name := acctest.RandomWithPrefix("pool-create")
+	ranges := fmt.Sprintf("%s,%s", internal.GetNewIpAddrRange(10), internal.GetNewIpAddr())
+
+	resourceName := "mikrotik_pool.bar"
+	resource.ParallelTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviderFactories,
+		CheckDestroy:      testAccCheckMikrotikPoolDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccPoolWithNextPool(name, ranges, "next_ip_pool", "next_ip_pool"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccPoolExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "ranges", ranges),
+					resource.TestCheckResourceAttr(resourceName, "next_pool", "next_ip_pool"),
+				),
+			},
+			{
+				Config: testAccPoolWithNextPool(name, ranges, "none", "next_ip_pool"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccPoolExists(resourceName),
+					resource.TestCheckResourceAttrSet(resourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "ranges", ranges),
+					resource.TestCheckResourceAttr(resourceName, "next_pool", ""),
+				),
+			},
+		},
+	})
+}
+
 func TestAccMikrotikPool_createAndPlanWithNonExistantPool(t *testing.T) {
 	name := acctest.RandomWithPrefix("pool-plan")
 	ranges := fmt.Sprintf("%s,%s", internal.GetNewIpAddrRange(10), internal.GetNewIpAddr())
@@ -153,6 +187,21 @@ resource "mikrotik_pool" "bar" {
     ranges = "%s"
 }
 `, name, ranges)
+}
+
+func testAccPoolWithNextPool(name, ranges, nextPoolToUse, nextPoolName string) string {
+	return fmt.Sprintf(`
+resource "mikrotik_pool" "bar" {
+    name = %q
+    ranges = %q
+	next_pool = %q
+}
+
+resource "mikrotik_pool" "next_pool" {
+    name = %q
+    ranges = "10.10.10.10-10.10.10.20"
+}
+`, name, ranges, nextPoolToUse, nextPoolName)
 }
 
 func testAccPoolWithComment(name, ranges, comment string) string {


### PR DESCRIPTION
This PR adds support of `next-pool` field to the `pool` resource.
Closes #23
