### PR TITLE
[client] add support for custom marshaling/unmarshaling

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-routeros/routeros/proto"
 )
 
+// Mikrotik struct defines connection parameters for RouterOS client
 type Mikrotik struct {
 	Host     string
 	Username string
@@ -27,6 +28,76 @@ type Mikrotik struct {
 	Insecure bool
 
 	connection *routeros.Client
+}
+
+type (
+	// Marshaler interface will be used to serialize struct to RouterOS sentence
+	Marshaler interface {
+		// MarshalMikrotik serializes Go type value as RouterOS field value
+		MarshalMikrotik() string
+	}
+
+	// Unmarshaler interface will be used to de-serialize reply from RouterOS into Go struct
+	Unmarshaler interface {
+		// UnmarshalMikrotik de-serializes RouterOS field into Go type value
+		UnmarshalMikrotik(string) error
+	}
+)
+
+func NewClient(host, username, password string, tls bool, caCertificate string, insecure bool) *Mikrotik {
+	return &Mikrotik{
+		Host:     host,
+		Username: username,
+		Password: password,
+		TLS:      tls,
+		CA:       caCertificate,
+		Insecure: insecure,
+	}
+}
+
+func Marshal(c string, s interface{}) []string {
+	var elem reflect.Value
+	rv := reflect.ValueOf(s)
+
+	if rv.Kind() == reflect.Ptr {
+		// get Value of what pointer points to
+		elem = rv.Elem()
+	} else {
+		elem = rv
+	}
+
+	cmd := []string{c}
+
+	for i := 0; i < elem.NumField(); i++ {
+		value := elem.Field(i)
+		fieldType := elem.Type().Field(i)
+		// supports multiple struct tags--assumes first is mikrotik field name
+		tag := strings.Split(fieldType.Tag.Get("mikrotik"), ",")[0]
+
+		if tag != "" && (!value.IsZero() || value.Kind() == reflect.Bool) {
+			if mar, ok := value.Interface().(Marshaler); ok {
+				// if type supports custom marshaling, use that result immediately
+				stringValue := mar.MarshalMikrotik()
+				cmd = append(cmd, fmt.Sprintf("=%s=%s", tag, stringValue))
+				continue
+			}
+
+			switch value.Kind() {
+			case reflect.Int:
+				intValue := elem.Field(i).Interface().(int)
+				cmd = append(cmd, fmt.Sprintf("=%s=%d", tag, intValue))
+			case reflect.String:
+				stringValue := elem.Field(i).Interface().(string)
+				cmd = append(cmd, fmt.Sprintf("=%s=%s", tag, stringValue))
+			case reflect.Bool:
+				boolValue := elem.Field(i).Interface().(bool)
+				stringBoolValue := boolToMikrotikBool(boolValue)
+				cmd = append(cmd, fmt.Sprintf("=%s=%s", tag, stringBoolValue))
+			}
+		}
+	}
+
+	return cmd
 }
 
 func Unmarshal(reply routeros.Reply, v interface{}) error {
@@ -70,90 +141,6 @@ func Unmarshal(reply routeros.Reply, v interface{}) error {
 	}
 
 	return nil
-}
-func parseStruct(v *reflect.Value, sentence proto.Sentence) {
-	elem := *v
-	for i := 0; i < elem.NumField(); i++ {
-		field := elem.Field(i)
-		fieldType := elem.Type().Field(i)
-		tags := strings.Split(fieldType.Tag.Get("mikrotik"), ",")
-
-		path := strings.ToLower(fieldType.Name)
-		fieldName := tags[0]
-
-		for _, pair := range sentence.List {
-			if strings.Compare(pair.Key, path) == 0 || strings.Compare(pair.Key, fieldName) == 0 {
-				switch fieldType.Type.Kind() {
-				case reflect.String:
-					field.SetString(pair.Value)
-				case reflect.Bool:
-					b, _ := strconv.ParseBool(pair.Value)
-					field.SetBool(b)
-				case reflect.Int:
-					if contains(tags, "ttlToSeconds") {
-						field.SetInt(int64(ttlToSeconds(pair.Value)))
-					} else {
-						intValue, _ := strconv.Atoi(pair.Value)
-						field.SetInt(int64(intValue))
-					}
-				}
-
-			}
-		}
-	}
-}
-
-func ttlToSeconds(ttl string) int {
-	parts := strings.Split(ttl, "d")
-
-	idx := 0
-	days := 0
-	var err error
-	if len(parts) == 2 {
-		idx = 1
-		days, err = strconv.Atoi(parts[0])
-
-		// We should be parsing an ascii number
-		// if this fails we should fail loudly
-		if err != nil {
-			panic(err)
-		}
-
-		// In the event we just get days parts[1] will be an
-		// empty string. Just coerce that into 0 seconds.
-		if parts[1] == "" {
-			parts[1] = "0s"
-		}
-	}
-	d, err := time.ParseDuration(parts[idx])
-
-	// We should never receive a duration greater than
-	// 23h59m59s. So this should always parse.
-	if err != nil {
-		panic(err)
-	}
-	return 86400*days + int(d)/int(math.Pow10(9))
-
-}
-
-func contains(s []string, e string) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}
-
-func NewClient(host, username, password string, tls bool, caCertificate string, insecure bool) *Mikrotik {
-	return &Mikrotik{
-		Host:     host,
-		Username: username,
-		Password: password,
-		TLS:      tls,
-		CA:       caCertificate,
-		Insecure: insecure,
-	}
 }
 
 func GetConfigFromEnv() (host, username, password string, tls bool, caCertificate string, insecure bool) {
@@ -224,48 +211,93 @@ func (client *Mikrotik) getMikrotikClient() (*routeros.Client, error) {
 	return mikrotikClient, nil
 }
 
+func parseStruct(v *reflect.Value, sentence proto.Sentence) {
+	elem := *v
+	for i := 0; i < elem.NumField(); i++ {
+		field := elem.Field(i)
+		fieldType := elem.Type().Field(i)
+		tags := strings.Split(fieldType.Tag.Get("mikrotik"), ",")
+
+		path := strings.ToLower(fieldType.Name)
+		fieldName := tags[0]
+
+		for _, pair := range sentence.List {
+			if strings.Compare(pair.Key, path) == 0 || strings.Compare(pair.Key, fieldName) == 0 {
+				if field.CanAddr() {
+					if unmar, ok := field.Addr().Interface().(Unmarshaler); ok {
+						// if type supports custom unmarshaling, try it and skip the rest
+						if err := unmar.UnmarshalMikrotik(pair.Value); err != nil {
+							log.Printf("[ERROR] cannot unmarshal RouterOS reply: %v", err)
+						}
+						continue
+					}
+				}
+
+				switch fieldType.Type.Kind() {
+				case reflect.String:
+					field.SetString(pair.Value)
+				case reflect.Bool:
+					b, _ := strconv.ParseBool(pair.Value)
+					field.SetBool(b)
+				case reflect.Int:
+					if contains(tags, "ttlToSeconds") {
+						field.SetInt(int64(ttlToSeconds(pair.Value)))
+					} else {
+						intValue, _ := strconv.Atoi(pair.Value)
+						field.SetInt(int64(intValue))
+					}
+				}
+			}
+		}
+	}
+}
+
+func ttlToSeconds(ttl string) int {
+	parts := strings.Split(ttl, "d")
+
+	idx := 0
+	days := 0
+	var err error
+	if len(parts) == 2 {
+		idx = 1
+		days, err = strconv.Atoi(parts[0])
+
+		// We should be parsing an ascii number
+		// if this fails we should fail loudly
+		if err != nil {
+			panic(err)
+		}
+
+		// In the event we just get days parts[1] will be an
+		// empty string. Just coerce that into 0 seconds.
+		if parts[1] == "" {
+			parts[1] = "0s"
+		}
+	}
+	d, err := time.ParseDuration(parts[idx])
+
+	// We should never receive a duration greater than
+	// 23h59m59s. So this should always parse.
+	if err != nil {
+		panic(err)
+	}
+	return 86400*days + int(d)/int(math.Pow10(9))
+
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}
+
 func boolToMikrotikBool(b bool) string {
 	if b {
 		return "yes"
 	} else {
 		return "no"
 	}
-}
-
-func Marshal(c string, s interface{}) []string {
-	var elem reflect.Value
-	rv := reflect.ValueOf(s)
-
-	if rv.Kind() == reflect.Ptr {
-		// get Value of what pointer points to
-		elem = rv.Elem()
-	} else {
-		elem = rv
-	}
-
-	cmd := []string{c}
-
-	for i := 0; i < elem.NumField(); i++ {
-		value := elem.Field(i)
-		fieldType := elem.Type().Field(i)
-		// supports multiple struct tags--assumes first is mikrotik field name
-		tag := strings.Split(fieldType.Tag.Get("mikrotik"), ",")[0]
-
-		if tag != "" && (!value.IsZero() || value.Kind() == reflect.Bool) {
-			switch value.Kind() {
-			case reflect.Int:
-				intValue := elem.Field(i).Interface().(int)
-				cmd = append(cmd, fmt.Sprintf("=%s=%d", tag, intValue))
-			case reflect.String:
-				stringValue := elem.Field(i).Interface().(string)
-				cmd = append(cmd, fmt.Sprintf("=%s=%s", tag, stringValue))
-			case reflect.Bool:
-				boolValue := elem.Field(i).Interface().(bool)
-				stringBoolValue := boolToMikrotikBool(boolValue)
-				cmd = append(cmd, fmt.Sprintf("=%s=%s", tag, stringBoolValue))
-			}
-		}
-	}
-
-	return cmd
 }

--- a/client/go.mod
+++ b/client/go.mod
@@ -2,4 +2,13 @@ module github.com/ddelnano/terraform-provider-mikrotik/client
 
 go 1.17
 
-require github.com/go-routeros/routeros v0.0.0-20210123142807-2a44d57c6730
+require (
+	github.com/go-routeros/routeros v0.0.0-20210123142807-2a44d57c6730
+	github.com/stretchr/testify v1.8.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/client/go.sum
+++ b/client/go.sum
@@ -1,2 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-routeros/routeros v0.0.0-20210123142807-2a44d57c6730 h1:EuqwWLv/LPPjhvFqkeD2bz+FOlvw2DjvDI7vK8GVeyY=
 github.com/go-routeros/routeros v0.0.0-20210123142807-2a44d57c6730/go.mod h1:em1mEqFKnoeQuQP9Sg7i26yaW8o05WwcNj7yLhrXxSQ=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/client/internal/types/list.go
+++ b/client/internal/types/list.go
@@ -1,0 +1,20 @@
+package types
+
+import (
+	"strings"
+)
+
+// MikrotikList type translates slice of strings to comma separated list and back
+//
+// It is useful to seamless serialize/deserialize data during communication with RouterOS
+type MikrotikList []string
+
+func (m MikrotikList) MarshalMikrotik() string {
+	return strings.Join(m, ",")
+}
+
+func (m *MikrotikList) UnmarshalMikrotik(value string) error {
+	*m = strings.Split(value, ",")
+
+	return nil
+}


### PR DESCRIPTION
This PR adds support for custom types with their own marshal/unmarshal process when using RouterOS client.

It works pretty much the same way as standard [json Marshaler](https://pkg.go.dev/encoding/json#Marshaler) interface.
The interface is:
```go
type (
	// Marshaler interface will be used to serialize struct to RouterOS sentence
	Marshaler interface {
		// MarshalMikrotik serializes Go type value as RouterOS field value
		MarshalMikrotik() string
	}

	// Unmarshaler interface will be used to de-serialize reply from RouterOS into Go struct
	Unmarshaler interface {
		// UnmarshalMikrotik de-serializes RouterOS field into Go type value
		UnmarshalMikrotik(string) error
	}
)
```

It is now possible to define custom type, e.g. `MikrotikList` so it is seamlessly converted to comma-separated list when the field is used in RouterOS API request, and splits back to Go `[]string` when response is being unmarshaled:
```go
type MikrotikList []string

func (m MikrotikList) MarshalMikrotik() string {
	return strings.Join(m, ",")
}

func (m *MikrotikList) UnmarshalMikrotik(value string) error {
	*m = strings.Split(value, ",")

	return nil
}
```

So this code:
```go
func TestCustomMarshaling(t *testing.T) {
	s := struct {
		Name string             `mikrotik:"name"`
		List types.MikrotikList `mikrotik:"list"`
	}{
		Name: "days",
		List: []string{"mon", "tue", "fri"},
	}

	result := Marshal("/dummy/command", s)
	t.Errorf("%#v\n", result)
}
```
results in output:
```go
[]string{"/dummy/command", "=name=days", "=list=mon,tue,fri"}
```

**NOTE**: I added `testify` to be used in testing, but if you think extra dependency is not a good idea, I can implement in-house testing utils - just let me know.