### PR TITLE
add local build section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,46 @@ You can discuss any issues you have or feature requests in [Discord](https://dis
 
 If you get value out this project and want to show your support you can find me on [patreon](https://www.patreon.com/ddelnano).
 
+## Building provider locally
+
+Requirements:
+* [Go](https://go.dev/doc/install) >= 1.16
+* [Terraform]() >= 0.14
+
+To build the provider with `make`:
+```shell
+$ make build
+```
+which creates a `terraform-provider-mikrotik` binary in repository's root folder.
+
+or build with `go` compiler:
+```shell
+$ go build -o terraform-provider-mikrotik
+```
+
+To use locally built provider, Terraform should be aware of its binary.
+
+It could be done with custom CLI config file:
+```hcl
+# custom.tfrc
+
+provider_installation {
+    dev_overrides {
+        "ddelnano/mikrotik" = "/path/to/clones/repository/terraform-provider-mikrotik"
+    }
+
+    direct {}
+}
+```
+The [dev_overrides](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers) section is available since Terraform `0.14`.
+
+Finally, tell Terraform CLI to use custom confiuration by exporting environment variable:
+```shell
+$ export TF_CLI_CONFIG_FILE=path/to/custom.tfrc
+```
+
+**NOTE**: with `dev_overrides` it is not possible to run `terraform init` (see [official docs](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers)) so you should immediately use `terraform plan` and `terraform apply` without initializing.
+
 ## Contributing
 
 ### Dependencies


### PR DESCRIPTION
This PR adds instructions about local building of the provider.
It could be useful for those who are not familiar with Go and want to test the latest features