### PR TITLE
Add client logic to support read-only Mikrotik properties

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -72,7 +72,7 @@ func Marshal(c string, s interface{}) []string {
 		// fetch mikrotik struct tag, which supports multiple values separated by commas
 		tags := fieldType.Tag.Get("mikrotik")
 		// extract tag value that is the Mikrotik property name
-		// it is assumed tha the first is mikrotik field name
+		// it is assumed that the first is mikrotik field name
 		mikrotikPropName := strings.Split(tags, ",")[0]
 
 		if mikrotikPropName != "" && (!value.IsZero() || value.Kind() == reflect.Bool) {

--- a/client/client.go
+++ b/client/client.go
@@ -69,28 +69,38 @@ func Marshal(c string, s interface{}) []string {
 	for i := 0; i < elem.NumField(); i++ {
 		value := elem.Field(i)
 		fieldType := elem.Type().Field(i)
-		// supports multiple struct tags--assumes first is mikrotik field name
-		tag := strings.Split(fieldType.Tag.Get("mikrotik"), ",")[0]
+		// fetch mikrotik struct tag, which supports multiple values separated by commas
+		tags := fieldType.Tag.Get("mikrotik")
+		// extract tag value that is the Mikrotik property name
+		// it is assumed tha the first is mikrotik field name
+		mikrotikPropName := strings.Split(tags, ",")[0]
 
-		if tag != "" && (!value.IsZero() || value.Kind() == reflect.Bool) {
+		if mikrotikPropName != "" && (!value.IsZero() || value.Kind() == reflect.Bool) {
+			// add conditional to check if a Mikrotik property is READ ONLY, such as the following wireguard props
+			// https://help.mikrotik.com/docs/display/ROS/WireGuard#WireGuard-Read-onlyproperties
+			if strings.Contains(tags, "readonly") {
+				// if a struct field contains the tag value of 'readonly', do not marshal it
+				continue
+			}
+
 			if mar, ok := value.Interface().(Marshaler); ok {
 				// if type supports custom marshaling, use that result immediately
 				stringValue := mar.MarshalMikrotik()
-				cmd = append(cmd, fmt.Sprintf("=%s=%s", tag, stringValue))
+				cmd = append(cmd, fmt.Sprintf("=%s=%s", mikrotikPropName, stringValue))
 				continue
 			}
 
 			switch value.Kind() {
 			case reflect.Int:
 				intValue := elem.Field(i).Interface().(int)
-				cmd = append(cmd, fmt.Sprintf("=%s=%d", tag, intValue))
+				cmd = append(cmd, fmt.Sprintf("=%s=%d", mikrotikPropName, intValue))
 			case reflect.String:
 				stringValue := elem.Field(i).Interface().(string)
-				cmd = append(cmd, fmt.Sprintf("=%s=%s", tag, stringValue))
+				cmd = append(cmd, fmt.Sprintf("=%s=%s", mikrotikPropName, stringValue))
 			case reflect.Bool:
 				boolValue := elem.Field(i).Interface().(bool)
 				stringBoolValue := boolToMikrotikBool(boolValue)
-				cmd = append(cmd, fmt.Sprintf("=%s=%s", tag, stringBoolValue))
+				cmd = append(cmd, fmt.Sprintf("=%s=%s", mikrotikPropName, stringBoolValue))
 			}
 		}
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -73,12 +73,18 @@ func Marshal(c string, s interface{}) []string {
 		tags := fieldType.Tag.Get("mikrotik")
 		// extract tag value that is the Mikrotik property name
 		// it is assumed that the first is mikrotik field name
-		mikrotikPropName := strings.Split(tags, ",")[0]
+		mikrotikTags := strings.Split(tags, ",")
+		mikrotikPropName := mikrotikTags[0]
+		// now we have field name in separate variable,
+		// so leave only modifiers in this slice
+		mikrotikTags = mikrotikTags[1:]
 
 		if mikrotikPropName != "" && (!value.IsZero() || value.Kind() == reflect.Bool) {
 			// add conditional to check if a Mikrotik property is READ ONLY, such as the following wireguard props
 			// https://help.mikrotik.com/docs/display/ROS/WireGuard#WireGuard-Read-onlyproperties
-			if strings.Contains(tags, "readonly") {
+			if contains(mikrotikTags, "readonly") {
+
+
 				// if a struct field contains the tag value of 'readonly', do not marshal it
 				continue
 			}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -234,6 +234,7 @@ func TestMarshal(t *testing.T) {
 				Name          string `mikrotik:"name"`
 				NotNamedOwner string `mikrotik:"owner,extraTagNotUsed"`
 				RunCount      int    `mikrotik:"run-count"`
+				ReadOnlyProp  bool   `mikrotik:"read-only-prop,readonly"`
 				Allowed       bool   `mikrotik:"allowed-or-not"`
 			}{
 				Name:          "test owner",


### PR DESCRIPTION
# Background
This PR adjusts logic in `client.go` related to Marshaling data before making API calls to a RouterOS device. While pairing with @DawoudMahmud on adding client support for creating Interface Wireguard resources (https://github.com/ddelnano/terraform-provider-mikrotik/pull/140, which is still a WIP), we came across Mikrotik documentation that lists some Wireguard properties to be ["Read Only](https://help.mikrotik.com/docs/display/ROS/WireGuard#WireGuard-Read-onlyproperties)".

This led to a test failure (see build [here](https://github.com/ddelnano/terraform-provider-mikrotik/actions/runs/4570066208/jobs/8066990862)) since a read-only boolean property `running` was included in the interface wireguard `add` command:

```
=== RUN   TestAddFindDeleteInterfaceWireguard
2023/03/30 23:54:57 [INFO] Running the mikrotik command: `[/interface/wireguard/add =name=new_interface_wireguard =comment=new interface from test =disabled=no =listen-port=10000 =mtu=10001 =private-key=YOi0P0lTTiN8hAQvuRET23Srb+U7C52iOZokj0CCSkM= =running=no]`
Error:     interface_wireguard_test.go:35: expected no error, got from RouterOS device: unknown parameter running
--- FAIL: TestAddFindDeleteInterfaceWireguard (0.04s)
```

The issue here is that the unset boolean struct field defaulted to a value of `false` and then was subsequently included in marshaling.

# What does this PR do?
- Adjust `client.go` in regards to how the `mikrotik` struct tag is retrieved, doing so in a way that we now check for a new `readonly` tag value.
- If `readonly` is specified as a struct tag value, that field will be excluded during marshaling.
- A test has been updated to illustrate that a field will _not_ be included in marshaling should the `readonly` struct tag value be present.