### PR TITLE
Configure goreleaser to use github-native changelog generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,14 @@
+changelog:
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - enhancement
+    - title: Bug fixes
+      labels:
+        - bug
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,4 +51,4 @@ release:
   # Visit your project's GitHub Releases page to publish this release.
   draft: true
 changelog:
-  skip: true
+  use: github-native


### PR DESCRIPTION
This addresses #149. I believe this is all that is needed to try out the github-native changelog generation. My plan is to merge this change, create a new release and verify if the release notes correctly populated.