### PR TITLE
Update goreleaser to publish GitHub releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -48,7 +48,6 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
-  # Visit your project's GitHub Releases page to publish this release.
-  draft: true
+  draft: false
 changelog:
   use: github-native


### PR DESCRIPTION
Since release change logs are automatically generated (#151) and given our acceptance tests give us strong validation that our code is functional, let's have `goreleaser` automatically publish releases. This will automate the final piece of manual work to create a release.

## Test plan
- Merge this change, create a `v0.11.0` tag and verify that a GitHub release is published automatically with our new release notes.