### PR TITLE
Add github workflow for `tfplugindocs` linting and unify setup-go and checkout action versions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,13 +27,13 @@ jobs:
             legacy_bgp_support: false
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Get dependencies
         run: go mod download

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,13 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       -
         name: Unshallow
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.18
       -

--- a/.github/workflows/tfplugindocs.yml
+++ b/.github/workflows/tfplugindocs.yml
@@ -15,19 +15,19 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.18
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
       - name: Get dependencies
         run: go mod download
       - name: Run tfplugindocs
         run: go generate ./...
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
       - name: Fail if any files changed
         shell: bash
         run: |
-          if [[ $(git status --porcelain=v1 | wc -l) -ne 0 ]]; then
-            echo "Please ensure tfplugindocs changes are committed"
+          if [[ $(git status --porcelain=v1 docs/ | wc -l) -ne 0 ]]; then
+            echo "Please ensure tfplugindocs changes are committed to docs/"
             echo "Changed files:"
-            git diff --name-only
+            git diff --name-only docs/
+            git status docs/
             exit 1
           fi

--- a/.github/workflows/tfplugindocs.yml
+++ b/.github/workflows/tfplugindocs.yml
@@ -1,0 +1,33 @@
+---
+name: 'tfplugindocs'
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  tfplugindocs:
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.18
+      - name: Get dependencies
+        run: go mod download
+      - name: Run tfplugindocs
+        run: go generate ./...
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+      - name: Fail if any files changed
+        shell: bash
+        run: |
+          if [[ $(git status --porcelain=v1 | wc -l) -ne 0 ]]; then
+            echo "Please ensure tfplugindocs changes are committed"
+            echo "Changed files:"
+            git diff --name-only
+            exit 1
+          fi

--- a/mikrotik/resource_scheduler.go
+++ b/mikrotik/resource_scheduler.go
@@ -47,7 +47,7 @@ func (s *scheduler) Metadata(_ context.Context, req resource.MetadataRequest, re
 // Schema defines the schema for the resource.
 func (s *scheduler) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Creates a Mikrotik scheduler.",
+		Description: "Creates a Mikrotik scheduler. this will fail",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,

--- a/mikrotik/resource_scheduler.go
+++ b/mikrotik/resource_scheduler.go
@@ -47,7 +47,7 @@ func (s *scheduler) Metadata(_ context.Context, req resource.MetadataRequest, re
 // Schema defines the schema for the resource.
 func (s *scheduler) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		Description: "Creates a Mikrotik scheduler. this will fail",
+		Description: "Creates a Mikrotik scheduler.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
 				Computed: true,


### PR DESCRIPTION
This PR adds a github workflow to prevent missing `tfplugindocs` updates (follow up for https://github.com/ddelnano/terraform-provider-mikrotik/pull/154). In addition to adding this workflow it upgrades the github action versions of setup-go and checkout for the existing workflows.

## Test plan
- [x] CI job will verify upgrade works for continuous-integration workflow
- [x] Valid changes have passing `tfplugindocs` [build](https://github.com/ddelnano/terraform-provider-mikrotik/actions/runs/4965881371/jobs/8886982269?pr=156)
- [x] Invalid build [fails](https://github.com/ddelnano/terraform-provider-mikrotik/actions/runs/4965892393/jobs/8887001216) as expected
- [ ] Release build is not tested, but CI job had similar upgrade and was successful