### PR TITLE
Add dependabot to monitor go and github action security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+---
+version: 2
+updates:
+  open-pull-requests-limit: 0
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  open-pull-requests-limit: 0
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 0


### PR DESCRIPTION
This adds the dependabot configuration so it can create PRs when there are security issues identified with our go or github action dependencies.