### PR TITLE
Poc generic crud functions

### DIFF
--- a/client/bridge_vlan_test.go
+++ b/client/bridge_vlan_test.go
@@ -10,7 +10,7 @@ import (
 func TestBridgeVlanBasic(t *testing.T) {
 	c := NewClient(GetConfigFromEnv())
 
-	bridge1Name := "test_bridge1"
+	bridge1Name := "test_bridge1_" + RandomString()
 	bridge1 := &Bridge{
 		Name:          bridge1Name,
 		FastForward:   false,
@@ -27,7 +27,7 @@ func TestBridgeVlanBasic(t *testing.T) {
 		}
 	}()
 
-	bridge2Name := "test_bridge2"
+	bridge2Name := "test_bridge2_" + RandomString()
 	bridge2 := &Bridge{
 		Name:          bridge2Name,
 		FastForward:   false,

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -12,10 +12,7 @@ func SkipLegacyBgpIfUnsupported(t *testing.T) {
 }
 
 func IsLegacyBgpSupported() bool {
-	if os.Getenv("LEGACY_BGP_SUPPORT") == "true" {
-		return true
-	}
-	return false
+	return os.Getenv("LEGACY_BGP_SUPPORT") == "true"
 }
 
 func SkipInterfaceWireguardIfUnsupported(t *testing.T) {
@@ -25,8 +22,5 @@ func SkipInterfaceWireguardIfUnsupported(t *testing.T) {
 }
 
 func IsInterfaceWireguardSupported() bool {
-	if os.Getenv("INTERFACE_WIREGUARD_SUPPORT") == "true" {
-		return true
-	}
-	return false
+	return os.Getenv("INTERFACE_WIREGUARD_SUPPORT") == "true"
 }

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -2,7 +2,9 @@ package client
 
 import (
 	"os"
+	"strconv"
 	"testing"
+	"time"
 )
 
 func SkipLegacyBgpIfUnsupported(t *testing.T) {
@@ -23,4 +25,10 @@ func SkipInterfaceWireguardIfUnsupported(t *testing.T) {
 
 func IsInterfaceWireguardSupported() bool {
 	return os.Getenv("INTERFACE_WIREGUARD_SUPPORT") == "true"
+}
+
+// RandomString returns a random string
+func RandomString() string {
+	// a naive implementation with all-digits for now
+	return strconv.FormatInt(time.Now().UTC().UnixNano(), 10)
 }

--- a/client/scheduler.go
+++ b/client/scheduler.go
@@ -1,10 +1,8 @@
 package client
 
 import (
-	"fmt"
-	"log"
-
 	"github.com/ddelnano/terraform-provider-mikrotik/client/types"
+	"github.com/go-routeros/routeros"
 )
 
 type Scheduler struct {
@@ -16,97 +14,81 @@ type Scheduler struct {
 	Interval  types.MikrotikDuration `mikrotik:"interval"`
 }
 
-func (client Mikrotik) FindScheduler(name string) (*Scheduler, error) {
-	c, err := client.getMikrotikClient()
+var _ Resource = (*Scheduler)(nil)
 
-	if err != nil {
-		return nil, err
-	}
-
-	cmd := []string{"/system/scheduler/print", "?name=" + name}
-	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
-	r, err := c.RunArgs(cmd)
-
-	log.Printf("[DEBUG] Found scheduler from mikrotik api %v", r)
-	scheduler := &Scheduler{}
-	err = Unmarshal(*r, scheduler)
-
-	if err != nil {
-		return nil, err
-	}
-
-	if scheduler.Name == "" {
-		return nil, NewNotFound(fmt.Sprintf("scheduler `%s` not found", name))
-	}
-	return scheduler, err
+func (b *Scheduler) ActionToCommand(a Action) string {
+	return map[Action]string{
+		Add:    "/system/scheduler/add",
+		Find:   "/system/scheduler/print",
+		Update: "/system/scheduler/set",
+		Delete: "/system/scheduler/remove",
+	}[a]
 }
 
-func (client Mikrotik) DeleteScheduler(name string) error {
-	c, err := client.getMikrotikClient()
-
-	if err != nil {
-		return err
-	}
-
-	scheduler, err := client.FindScheduler(name)
-
-	if err != nil {
-		return err
-	}
-	cmd := []string{"/system/scheduler/remove", "=numbers=" + scheduler.Id}
-	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
-	r, err := c.RunArgs(cmd)
-	log.Printf("[DEBUG] Remove scheduler from mikrotik api %v", r)
-
-	return err
+func (b *Scheduler) IDField() string {
+	return ".id"
 }
 
-// AddScheduler is an alias to CreateScheduler
+func (b *Scheduler) ID() string {
+	return b.Id
+}
+
+func (b *Scheduler) SetID(id string) {
+	b.Id = id
+}
+
+func (b *Scheduler) AfterAddHook(r *routeros.Reply) {
+	b.Id = r.Done.Map["ret"]
+}
+
+func (b *Scheduler) FindField() string {
+	return "name"
+}
+
+func (b *Scheduler) FindFieldValue() string {
+	return b.Name
+}
+
+func (b *Scheduler) DeleteField() string {
+	return "numbers"
+}
+
+func (b *Scheduler) DeleteFieldValue() string {
+	return b.Id
+}
+
+// typed wrappers
 func (client Mikrotik) AddScheduler(s *Scheduler) (*Scheduler, error) {
 	return client.CreateScheduler(s)
 }
 
 func (client Mikrotik) CreateScheduler(s *Scheduler) (*Scheduler, error) {
-	c, err := client.getMikrotikClient()
-
+	r, err := client.Add(s)
 	if err != nil {
 		return nil, err
 	}
 
-	cmd := Marshal("/system/scheduler/add", s)
-
-	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
-	r, err := c.RunArgs(cmd)
-	log.Printf("[DEBUG] /system/scheduler/add returned %v", r)
-
-	if err != nil {
-		return nil, err
-	}
-
-	return client.FindScheduler(s.Name)
+	return r.(*Scheduler), nil
 }
 
 func (client Mikrotik) UpdateScheduler(s *Scheduler) (*Scheduler, error) {
-	c, err := client.getMikrotikClient()
-
+	r, err := client.Update(s)
 	if err != nil {
 		return nil, err
 	}
 
-	scheduler, err := client.FindScheduler(s.Name)
+	return r.(*Scheduler), nil
+}
 
+func (client Mikrotik) FindScheduler(name string) (*Scheduler, error) {
+	r, err := client.Find(&Scheduler{Name: name})
 	if err != nil {
-		return scheduler, err
+		return nil, err
 	}
 
-	cmd := Marshal("/system/scheduler/set", s)
+	return r.(*Scheduler), nil
+}
 
-	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
-	_, err = c.RunArgs(cmd)
-
-	if err != nil {
-		return scheduler, err
-	}
-
-	return client.FindScheduler(s.Name)
+func (client Mikrotik) DeleteScheduler(name string) error {
+	return client.Delete(&Scheduler{Name: name})
 }

--- a/client/scheduler_test.go
+++ b/client/scheduler_test.go
@@ -1,16 +1,16 @@
 package client
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/ddelnano/terraform-provider-mikrotik/client/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateUpdateDeleteAndFindScheduler(t *testing.T) {
 	c := NewClient(GetConfigFromEnv())
 
-	schedulerName := "scheduler"
+	schedulerName := "scheduler_" + RandomString()
 	onEvent := "onevent"
 	interval := 0
 	expectedScheduler := &Scheduler{
@@ -19,32 +19,22 @@ func TestCreateUpdateDeleteAndFindScheduler(t *testing.T) {
 		Interval: types.MikrotikDuration(interval),
 	}
 	scheduler, err := c.CreateScheduler(expectedScheduler)
-
-	if err != nil || scheduler == nil {
-		t.Errorf("Error creating a scheduler with: %v and value: %v", err, scheduler)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, scheduler)
 
 	expectedScheduler.Id = scheduler.Id
 	expectedScheduler.StartDate = scheduler.StartDate
 	expectedScheduler.StartTime = scheduler.StartTime
 
-	if !reflect.DeepEqual(scheduler, expectedScheduler) {
-		t.Errorf("The scheduler does not match what we expected. actual: %v expected: %v", scheduler, expectedScheduler)
-	}
+	require.Equal(t, expectedScheduler, scheduler)
 
 	// update and reassert
 	expectedScheduler.OnEvent = "test"
 	scheduler, err = c.UpdateScheduler(expectedScheduler)
-
-	if !reflect.DeepEqual(scheduler, expectedScheduler) {
-		t.Errorf("The updated scheduler does not match what we expected. actual: %v expected: %v", scheduler, expectedScheduler)
-	}
+	require.Equal(t, expectedScheduler, scheduler)
 
 	err = c.DeleteScheduler(schedulerName)
-
-	if err != nil {
-		t.Errorf("Error deleting a scheduler with: %v", err)
-	}
+	require.NoError(t, err)
 }
 
 func TestFindScheduler_onNonExistantScript(t *testing.T) {


### PR DESCRIPTION
This PR shows how to use `Generic..Resource` functions for Terraform resources (introduced in #161).

I created this PR against `terraform-model-client-struct-marshalling` branch to show only resource changes.

As you can see, the amount of code significantly reduced, so code generation could be done with less effort from our side - no need to implement `modelToXXXX()` and `XXXXToModel()` anymore