### PR TITLE
unify the way of client error checking

### DIFF
--- a/client/bgp_instance_test.go
+++ b/client/bgp_instance_test.go
@@ -3,6 +3,8 @@ package client
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var bgpName string = "test-bgp"
@@ -120,7 +122,6 @@ func TestFindBgpInstance_onNonExistantBgpInstance(t *testing.T) {
 	name := "bgp instance does not exist"
 	_, err := c.FindBgpInstance(name)
 
-	if _, ok := err.(*NotFound); !ok {
-		t.Errorf("Expecting to receive NotFound error for bgp instance `%s`, instead error was nil.", name)
-	}
+	require.Truef(t, IsNotFoundError(err),
+		"Expecting to receive NotFound error for bgp instance %q", name)
 }

--- a/client/bgp_peer_test.go
+++ b/client/bgp_peer_test.go
@@ -3,6 +3,8 @@ package client
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // required BGP Peer fields
@@ -129,7 +131,6 @@ func TestFindBgpPeer_onNonExistantBgpPeer(t *testing.T) {
 	name := "bgp peer does not exist"
 	_, err := c.FindBgpPeer(name)
 
-	if _, ok := err.(*NotFound); !ok {
-		t.Errorf("Expecting to receive NotFound error for bgp peer `%s`, instead error was nil.", name)
-	}
+	require.Truef(t, IsNotFoundError(err),
+		"Expecting to receive NotFound error for bgp peer %q.", name)
 }

--- a/client/bridge_port_test.go
+++ b/client/bridge_port_test.go
@@ -1,9 +1,10 @@
 package client
 
 import (
-	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestBridgePort_basic(t *testing.T) {
@@ -25,19 +26,14 @@ func TestBridgePort_basic(t *testing.T) {
 		Bridge:    bridge.Name,
 		Interface: "*0",
 	})
-	if err != nil {
-		t.Fatal(err)
-		return
-	}
-	defer func() {
-		if err := c.DeleteBridgePort(bridgePort.Id); err != nil {
-			t.Error(err)
+	require.NoError(t, err)
 
-		}
-		expected := &NotFound{}
-		if _, err := c.FindBridgePort(bridgePort.Id); err == nil || !errors.As(err, &expected) {
-			t.Error(err)
-		}
+	defer func() {
+		c.DeleteBridgePort(bridgePort.Id)
+		require.NoError(t, err)
+
+		_, err = c.FindBridgePort(bridgePort.Id)
+		require.True(t, IsNotFoundError(err), "expected to get NotFound error")
 	}()
 
 	expected := &BridgePort{

--- a/client/dns_test.go
+++ b/client/dns_test.go
@@ -1,9 +1,10 @@
 package client
 
 import (
-	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestFindDnsRecord_onNonExistantDnsRecord(t *testing.T) {
@@ -12,9 +13,8 @@ func TestFindDnsRecord_onNonExistantDnsRecord(t *testing.T) {
 	name := "dns record does not exist"
 	_, err := c.FindDnsRecord(name)
 
-	if _, ok := err.(*NotFound); !ok {
-		t.Errorf("Expecting to receive NotFound error for dns record `%s`, instead error was nil.", name)
-	}
+	require.Truef(t, IsNotFoundError(err),
+		"Expecting to receive NotFound error for dns record %q", name)
 }
 
 func TestAddFindDeleteDnsRecord(t *testing.T) {
@@ -55,13 +55,8 @@ func TestAddFindDeleteDnsRecord(t *testing.T) {
 	}
 
 	_, err = c.Find(findRecord)
-	if err == nil {
-		t.Errorf("expected error, got nothing")
-		return
-	}
+	require.Error(t, err)
 
-	target := &NotFound{}
-	if !errors.As(err, &target) {
-		t.Errorf("expected error to be of type %T, got %T", &NotFound{}, err)
-	}
+	require.True(t, IsNotFoundError(err),
+		"expected to get NotFound error")
 }

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,13 +1,22 @@
 package client
 
+import "errors"
+
 type NotFound struct {
 	s string
 }
 
 func NewNotFound(text string) error {
-	return &NotFound{text}
+	return NotFound{text}
 }
 
-func (e *NotFound) Error() string {
+func (e NotFound) Error() string {
 	return e.s
+}
+
+func IsNotFoundError(err error) bool {
+	var e NotFound
+	var ePtr *NotFound
+
+	return errors.As(err, &e) || errors.As(err, &ePtr)
 }

--- a/client/errors_test.go
+++ b/client/errors_test.go
@@ -1,0 +1,54 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsNotFoundError(t *testing.T) {
+
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			expected: false,
+		},
+		{
+			name:     "created via NewNotFoundError()",
+			err:      NewNotFound("not found"),
+			expected: true,
+		},
+		{
+			name:     "created directly via struct initialization",
+			err:      NotFound{},
+			expected: true,
+		},
+		{
+			name:     "chained with other errors",
+			err:      fmt.Errorf("cannot load object info: %w", NewNotFound("no such object")),
+			expected: true,
+		},
+		{
+			name:     "chain of non-matching errors",
+			err:      fmt.Errorf("cannot load object info: %w", errors.New("no such object")),
+			expected: false,
+		},
+		{
+			name:     "generic error",
+			err:      errors.New("no such object"),
+			expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := IsNotFoundError(tc.err)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/client/interface_wireguard_test.go
+++ b/client/interface_wireguard_test.go
@@ -1,9 +1,10 @@
 package client
 
 import (
-	"errors"
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestFindInterfaceWireguard_onNonExistantInterfaceWireguard(t *testing.T) {
@@ -13,9 +14,8 @@ func TestFindInterfaceWireguard_onNonExistantInterfaceWireguard(t *testing.T) {
 	name := "Interface wireguard does not exist"
 	_, err := c.FindInterfaceWireguard(name)
 
-	if _, ok := err.(*NotFound); !ok {
-		t.Errorf("Expecting to receive NotFound error for Interface wireguard `%s`, instead error was nil.", name)
-	}
+	require.Truef(t, IsNotFoundError(err),
+		"Expecting to receive NotFound error for Interface wireguard %q.", name)
 }
 
 func TestAddFindDeleteInterfaceWireguard(t *testing.T) {
@@ -39,14 +39,12 @@ func TestAddFindDeleteInterfaceWireguard(t *testing.T) {
 	}
 	defer func() {
 		err = c.Delete(interfaceWireguard)
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
-		expected := &NotFound{}
-		if _, err := c.Find(interfaceWireguard); err == nil || !errors.As(err, &expected) {
-			t.Error(err)
-		}
+		require.NoError(t, err)
+
+		_, err := c.Find(interfaceWireguard)
+		require.True(t, IsNotFoundError(err), "expected to get NotFound error")
 	}()
+
 	findInterface := &InterfaceWireguard{}
 	findInterface.Name = name
 	found, err := c.Find(findInterface)

--- a/client/pool_test.go
+++ b/client/pool_test.go
@@ -3,6 +3,8 @@ package client
 import (
 	"reflect"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 var name string = "testacc"
@@ -55,9 +57,7 @@ func TestFindPool_forNonExistingPool(t *testing.T) {
 	poolId := "Invalid id"
 	_, err := c.FindPool(poolId)
 
-	if _, ok := err.(*NotFound); !ok {
-		t.Errorf("client should have NotFound error error but instead received '%v'", err)
-	}
+	require.Truef(t, IsNotFoundError(err), "client should have NotFound error error but instead received")
 }
 
 func TestFindPoolByName_forExistingPool(t *testing.T) {
@@ -86,7 +86,6 @@ func TestFindPoolByName_forNonExistingPool(t *testing.T) {
 	poolName := "Invalid name"
 	_, err := c.FindPoolByName(poolName)
 
-	if _, ok := err.(*NotFound); !ok {
-		t.Errorf("client should have NotFound error error but instead received '%v'", err)
-	}
+	require.True(t, IsNotFoundError(err),
+		"client should have NotFound error")
 }

--- a/client/scheduler_test.go
+++ b/client/scheduler_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/ddelnano/terraform-provider-mikrotik/client/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCreateUpdateDeleteAndFindScheduler(t *testing.T) {
@@ -53,7 +54,6 @@ func TestFindScheduler_onNonExistantScript(t *testing.T) {
 	name := "scheduler does not exist"
 	_, err := c.FindScheduler(name)
 
-	if _, ok := err.(*NotFound); !ok {
-		t.Errorf("Expecting to receive NotFound error for scheduler `%s`, instead error was nil.", name)
-	}
+	require.Truef(t, IsNotFoundError(err),
+		"Expecting to receive NotFound error for scheduler %q.", name)
 }

--- a/mikrotik/resource_bgp_instance.go
+++ b/mikrotik/resource_bgp_instance.go
@@ -92,12 +92,12 @@ func resourceBgpInstance() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: " If enabled, the router will redistribute the information about static routes added to its routing database.",
+				Description: "If enabled, the router will redistribute the information about static routes added to its routing database.",
 			},
 			"router_id": {
-				Type:     schema.TypeString,
-				Required: true,
-				Description: " 	BGP Router ID (for this instance). If set to 0.0.0.0, BGP will use one of router's IP addresses.",
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "BGP Router ID (for this instance). If set to 0.0.0.0, BGP will use one of router's IP addresses.",
 			},
 			"routing_table": {
 				Type:        schema.TypeString,
@@ -106,9 +106,9 @@ func resourceBgpInstance() *schema.Resource {
 				Description: "Name of routing table this BGP instance operates on. ",
 			},
 			"cluster_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Description: " 	In case this instance is a route reflector: cluster ID of the router reflector cluster this instance belongs to.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "In case this instance is a route reflector: cluster ID of the router reflector cluster this instance belongs to.",
 			},
 			"confederation": {
 				Type:        schema.TypeInt,
@@ -141,7 +141,7 @@ func resourceBgpInstanceRead(ctx context.Context, d *schema.ResourceData, m inte
 		return diag.FromErr(err)
 	}
 
-	if _, ok := err.(*client.NotFound); ok {
+	if client.IsNotFoundError(err) {
 		d.SetId("")
 		return nil
 	}

--- a/mikrotik/resource_bgp_instance_test.go
+++ b/mikrotik/resource_bgp_instance_test.go
@@ -239,8 +239,7 @@ func testAccCheckMikrotikBgpInstanceDestroy(s *terraform.State) error {
 
 		bgpInstance, err := apiClient.FindBgpInstance(rs.Primary.ID)
 
-		_, ok := err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return err
 		}
 

--- a/mikrotik/resource_bgp_peer.go
+++ b/mikrotik/resource_bgp_peer.go
@@ -188,7 +188,7 @@ func resourceBgpPeerRead(ctx context.Context, d *schema.ResourceData, m interfac
 	c := m.(*client.Mikrotik)
 
 	bgpPeer, err := c.FindBgpPeer(d.Id())
-	if _, ok := err.(*client.NotFound); ok {
+	if client.IsNotFoundError(err) {
 		d.SetId("")
 		return nil
 	}

--- a/mikrotik/resource_bgp_peer_test.go
+++ b/mikrotik/resource_bgp_peer_test.go
@@ -265,8 +265,7 @@ func testAccCheckMikrotikBgpPeerDestroy(s *terraform.State) error {
 
 		bgpPeer, err := c.FindBgpPeer(rs.Primary.ID)
 
-		_, ok := err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return err
 		}
 

--- a/mikrotik/resource_bridge.go
+++ b/mikrotik/resource_bridge.go
@@ -64,7 +64,7 @@ func resourceBridgeRead(ctx context.Context, d *schema.ResourceData, m interface
 	var diags diag.Diagnostics
 	c := m.(*client.Mikrotik)
 	bridge, err := c.FindBridge(d.Id())
-	if _, ok := err.(*client.NotFound); ok {
+	if client.IsNotFoundError(err) {
 		d.SetId("")
 		return nil
 	}

--- a/mikrotik/resource_bridge_port.go
+++ b/mikrotik/resource_bridge_port.go
@@ -65,7 +65,7 @@ func resourceBridgePortCreate(ctx context.Context, d *schema.ResourceData, m int
 func resourceBridgePortRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.Mikrotik)
 	bridgePort, err := c.FindBridgePort(d.Id())
-	if _, ok := err.(*client.NotFound); ok {
+	if client.IsNotFoundError(err) {
 		d.SetId("")
 		return nil
 	}

--- a/mikrotik/resource_bridge_port_test.go
+++ b/mikrotik/resource_bridge_port_test.go
@@ -73,8 +73,7 @@ func testAccCheckBridgePortDestroy(s *terraform.State) error {
 		}
 
 		remoteRecord, err := c.FindBridgePort(rs.Primary.ID)
-		_, ok := err.(*client.NotFound)
-		if err != nil && !ok {
+		if err != nil && !client.IsNotFoundError(err) {
 			return fmt.Errorf("expected not found error, got %+#v", err)
 		}
 

--- a/mikrotik/resource_bridge_test.go
+++ b/mikrotik/resource_bridge_test.go
@@ -69,8 +69,7 @@ func testAccBridgeDestroy(s *terraform.State) error {
 		}
 
 		remoteRecord, err := c.FindBridge(rs.Primary.ID)
-		_, ok := err.(*client.NotFound)
-		if err != nil && !ok {
+		if err != nil && !client.IsNotFoundError(err) {
 			return fmt.Errorf("expected not found error, got %+#v", err)
 		}
 

--- a/mikrotik/resource_bridge_vlan.go
+++ b/mikrotik/resource_bridge_vlan.go
@@ -74,7 +74,7 @@ func resourceBridgeVlanCreate(ctx context.Context, d *schema.ResourceData, m int
 func resourceBridgeVlanRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.Mikrotik)
 	r, err := c.FindBridgeVlan(d.Id())
-	if _, ok := err.(*client.NotFound); ok {
+	if client.IsNotFoundError(err) {
 		d.SetId("")
 		return nil
 	}

--- a/mikrotik/resource_bridge_vlan_test.go
+++ b/mikrotik/resource_bridge_vlan_test.go
@@ -60,8 +60,7 @@ func testAccCheckBridgeVlanDestroy(s *terraform.State) error {
 		}
 
 		remoteRecord, err := c.FindBridgeVlan(rs.Primary.ID)
-		_, ok := err.(*client.NotFound)
-		if err != nil && !ok {
+		if err != nil && !client.IsNotFoundError(err) {
 			return fmt.Errorf("expected not found error, got %+#v", err)
 		}
 

--- a/mikrotik/resource_dhcp_lease.go
+++ b/mikrotik/resource_dhcp_lease.go
@@ -77,7 +77,7 @@ func resourceLeaseRead(ctx context.Context, d *schema.ResourceData, m interface{
 
 	lease, err := c.FindDhcpLease(d.Id())
 
-	if _, ok := err.(*client.NotFound); ok {
+	if client.IsNotFoundError(err) {
 		d.SetId("")
 		return nil
 	}

--- a/mikrotik/resource_dhcp_lease_test.go
+++ b/mikrotik/resource_dhcp_lease_test.go
@@ -220,8 +220,7 @@ func testAccCheckMikrotikDhcpLeaseDestroy(s *terraform.State) error {
 
 		dhcpLease, err := c.FindDhcpLease(rs.Primary.ID)
 
-		_, ok := err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return err
 		}
 

--- a/mikrotik/resource_dhcp_server_network.go
+++ b/mikrotik/resource_dhcp_server_network.go
@@ -72,7 +72,7 @@ func resourceDhcpServerNetworkCreate(ctx context.Context, d *schema.ResourceData
 func resourceDhcpServerNetworkRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.Mikrotik)
 	record, err := c.FindDhcpServerNetwork(d.Id())
-	if _, ok := err.(*client.NotFound); ok {
+	if client.IsNotFoundError(err) {
 		d.SetId("")
 		return nil
 	}

--- a/mikrotik/resource_dhcp_server_network_test.go
+++ b/mikrotik/resource_dhcp_server_network_test.go
@@ -71,8 +71,7 @@ func testAccCheckDhcpServerNetworkDestroy(s *terraform.State) error {
 
 		remoteRecord, err := c.FindDhcpServerNetwork(rs.Primary.ID)
 
-		_, ok := err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return err
 		}
 

--- a/mikrotik/resource_dhcp_server_test.go
+++ b/mikrotik/resource_dhcp_server_test.go
@@ -69,8 +69,7 @@ func testAccCheckDhcpServerDestroy(s *terraform.State) error {
 		}
 
 		dhcpServer, err := c.FindDhcpServer(rs.Primary.ID)
-		_, ok := err.(*client.NotFound)
-		if err != nil && !ok {
+		if err != nil && !client.IsNotFoundError(err) {
 			return fmt.Errorf("expected not found error, got %+#v", err)
 		}
 

--- a/mikrotik/resource_dns_record.go
+++ b/mikrotik/resource_dns_record.go
@@ -66,7 +66,7 @@ func resourceServerRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	record, err := c.FindDnsRecord(d.Id())
 
-	if _, ok := err.(*client.NotFound); ok {
+	if client.IsNotFoundError(err) {
 		d.SetId("")
 		return nil
 	}

--- a/mikrotik/resource_dns_record_test.go
+++ b/mikrotik/resource_dns_record_test.go
@@ -210,8 +210,7 @@ func testAccCheckMikrotikDnsRecordDestroy(s *terraform.State) error {
 
 		dnsRecord, err := c.FindDnsRecord(rs.Primary.ID)
 
-		_, ok := err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return err
 		}
 

--- a/mikrotik/resource_firewall_filter_rule_test.go
+++ b/mikrotik/resource_firewall_filter_rule_test.go
@@ -56,8 +56,7 @@ func testAccCheckFirewallFilterRuleDestroy(s *terraform.State) error {
 		}
 
 		remoteRecord, err := c.FindFirewallFilterRule(rs.Primary.ID)
-		_, ok := err.(*client.NotFound)
-		if err != nil && !ok {
+		if err != nil && !client.IsNotFoundError(err) {
 			return fmt.Errorf("expected not found error, got %+#v", err)
 		}
 

--- a/mikrotik/resource_interface_list_member.go
+++ b/mikrotik/resource_interface_list_member.go
@@ -55,7 +55,7 @@ func resourceInterfaceListMemberCreate(ctx context.Context, d *schema.ResourceDa
 func resourceInterfaceListMemberRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.Mikrotik)
 	record, err := c.FindInterfaceListMember(d.Id())
-	if _, ok := err.(*client.NotFound); ok {
+	if client.IsNotFoundError(err) {
 		d.SetId("")
 		return nil
 	}

--- a/mikrotik/resource_interface_list_member_test.go
+++ b/mikrotik/resource_interface_list_member_test.go
@@ -72,8 +72,7 @@ func testAccCheckInterfaceListMemberDestroy(s *terraform.State) error {
 		}
 
 		remoteRecord, err := c.FindInterfaceListMember(rs.Primary.ID)
-		_, ok := err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return err
 		}
 

--- a/mikrotik/resource_interface_list_test.go
+++ b/mikrotik/resource_interface_list_test.go
@@ -44,8 +44,7 @@ func testAccCheckInterfaceListDestroy(s *terraform.State) error {
 		}
 
 		remoteRecord, err := c.FindInterfaceList(rs.Primary.ID)
-		_, ok := err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return err
 		}
 

--- a/mikrotik/resource_interface_wireguard_test.go
+++ b/mikrotik/resource_interface_wireguard_test.go
@@ -129,8 +129,7 @@ func testAccCheckMikrotikInterfaceWireguardDestroy(s *terraform.State) error {
 
 		interfaceWireguard, err := c.FindInterfaceWireguard(rs.Primary.Attributes["name"])
 
-		_, ok := err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return err
 		}
 
@@ -156,8 +155,7 @@ func testAccInterfaceWireguardExists(resourceName string) resource.TestCheckFunc
 
 		interfaceWireguard, err := c.FindInterfaceWireguard(rs.Primary.Attributes["name"])
 
-		_, ok = err.(*client.NotFound)
-		if !ok && err != nil {
+		if err != nil {
 			return fmt.Errorf("Unable to get the interface wireguard with error: %v", err)
 		}
 

--- a/mikrotik/resource_ip_address.go
+++ b/mikrotik/resource_ip_address.go
@@ -72,8 +72,7 @@ func resourceIpAddressRead(ctx context.Context, d *schema.ResourceData, m interf
 	ipaddr, err := c.FindIpAddress(d.Id())
 
 	// Clear the state if the error represents that the resource no longer exists
-	_, resourceMissing := err.(*client.NotFound)
-	if resourceMissing && err != nil {
+	if client.IsNotFoundError(err) {
 		d.SetId("")
 		return nil
 	}

--- a/mikrotik/resource_ip_address_test.go
+++ b/mikrotik/resource_ip_address_test.go
@@ -155,8 +155,7 @@ func testAccCheckMikrotikIpAddressDestroy(s *terraform.State) error {
 
 		ipaddr, err := c.FindIpAddress(rs.Primary.ID)
 
-		_, ok := err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return err
 		}
 
@@ -164,5 +163,6 @@ func testAccCheckMikrotikIpAddressDestroy(s *terraform.State) error {
 			return fmt.Errorf("ip address (%s) still exists", ipaddr.Id)
 		}
 	}
+
 	return nil
 }

--- a/mikrotik/resource_ipv6_address.go
+++ b/mikrotik/resource_ipv6_address.go
@@ -87,8 +87,7 @@ func resourceIpv6AddressRead(ctx context.Context, d *schema.ResourceData, m inte
 	ipv6addr, err := c.FindIpv6Address(d.Id())
 
 	// Clear the state if the error represents that the resource no longer exists
-	_, resourceMissing := err.(*client.NotFound)
-	if resourceMissing && err != nil {
+	if client.IsNotFoundError(err) {
 		d.SetId("")
 		return nil
 	}

--- a/mikrotik/resource_ipv6_address_test.go
+++ b/mikrotik/resource_ipv6_address_test.go
@@ -163,8 +163,7 @@ func testAccCheckMikrotikIpv6AddressDestroy(s *terraform.State) error {
 
 		ipaddr, err := c.FindIpv6Address(rs.Primary.ID)
 
-		_, ok := err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return err
 		}
 

--- a/mikrotik/resource_pool.go
+++ b/mikrotik/resource_pool.go
@@ -75,7 +75,7 @@ func resourcePoolRead(ctx context.Context, d *schema.ResourceData, m interface{}
 
 	pool, err := c.FindPool(d.Id())
 
-	if _, ok := err.(*client.NotFound); ok {
+	if client.IsNotFoundError(err) {
 		d.SetId("")
 		return nil
 	}

--- a/mikrotik/resource_pool_test.go
+++ b/mikrotik/resource_pool_test.go
@@ -254,8 +254,7 @@ func testAccCheckMikrotikPoolDestroy(s *terraform.State) error {
 
 		pool, err := c.FindPool(rs.Primary.ID)
 
-		_, ok := err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return err
 		}
 

--- a/mikrotik/resource_scheduler_test.go
+++ b/mikrotik/resource_scheduler_test.go
@@ -156,8 +156,7 @@ func testAccCheckMikrotikSchedulerDestroy(s *terraform.State) error {
 
 		scheduler, err := c.FindScheduler(rs.Primary.ID)
 
-		_, ok := err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return err
 		}
 
@@ -183,8 +182,7 @@ func testAccSchedulerExists(resourceName string) resource.TestCheckFunc {
 
 		scheduler, err := c.FindScheduler(rs.Primary.Attributes["name"])
 
-		_, ok = err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return fmt.Errorf("Unable to get the scheduler with error: %v", err)
 		}
 

--- a/mikrotik/resource_script.go
+++ b/mikrotik/resource_script.go
@@ -108,7 +108,7 @@ func resourceScriptRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	script, err := c.FindScript(d.Id())
 
-	if _, ok := err.(*client.NotFound); ok {
+	if client.IsNotFoundError(err) {
 		d.SetId("")
 		return nil
 	}

--- a/mikrotik/resource_script_test.go
+++ b/mikrotik/resource_script_test.go
@@ -197,8 +197,7 @@ func testAccCheckMikrotikScriptDestroy(s *terraform.State) error {
 
 		script, err := c.FindScript(rs.Primary.ID)
 
-		_, ok := err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return err
 		}
 
@@ -224,8 +223,7 @@ func testAccScriptExists(resourceName string) resource.TestCheckFunc {
 
 		script, err := c.FindScript(rs.Primary.ID)
 
-		_, ok = err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return fmt.Errorf("Unable to get the script with error: %v", err)
 		}
 

--- a/mikrotik/resource_vlan_interface_test.go
+++ b/mikrotik/resource_vlan_interface_test.go
@@ -81,8 +81,7 @@ func testAccCheckVlanInterfaceDestroy(s *terraform.State) error {
 
 		remoteRecord, err := c.FindVlanInterface(rs.Primary.ID)
 
-		_, ok := err.(*client.NotFound)
-		if !ok && err != nil {
+		if !client.IsNotFoundError(err) && err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This PR adds `IsNotFoundError()` helper function to 'hide' actual implementation of the error and make the process of checking for this error type easier.