### PR TITLE
add client.List() support, refactor client ip_addr

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -84,7 +84,6 @@ func Marshal(c string, s interface{}) []string {
 			// https://help.mikrotik.com/docs/display/ROS/WireGuard#WireGuard-Read-onlyproperties
 			if contains(mikrotikTags, "readonly") {
 
-
 				// if a struct field contains the tag value of 'readonly', do not marshal it
 				continue
 			}


### PR DESCRIPTION
This PR contains improvements to `client_crud` operations: new `List()` operation to enumerate resources is available.

`List()` returns a `slice of pointers` to MikroTik resources.