### PR TITLE
Add helper functions for RouterOS version detection and use for feature opt out

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -18,15 +18,11 @@ jobs:
         os: [ubuntu-latest]
         # Test against latest stable release, v6 beta and v7 beta
         routeros: ["6.48.3", "6.49beta54"]
-        legacy_bgp_support: [true]
-        interface_wireguard_support: [false]
         include:
           - experimental: true
             go: 1.18
             os: ubuntu-latest
             routeros: "latest"
-            legacy_bgp_support: false
-            interface_wireguard_support: true
 
     steps:
       - name: Set up Go
@@ -54,8 +50,6 @@ jobs:
           MIKROTIK_USER: admin
           MIKROTIK_PASSWORD: ''
           TF_ACC: 1
-          LEGACY_BGP_SUPPORT: ${{ matrix.legacy_bgp_support }}
-          INTERFACE_WIREGUARD_SUPPORT: ${{ matrix.interface_wireguard_support }}
 
       - name: Run client tests
         run: make testclient
@@ -64,8 +58,6 @@ jobs:
           MIKROTIK_USER: admin
           MIKROTIK_PASSWORD: ''
           TF_ACC: 1
-          LEGACY_BGP_SUPPORT: ${{ matrix.legacy_bgp_support }}
-          INTERFACE_WIREGUARD_SUPPORT: ${{ matrix.interface_wireguard_support }}
 
     services:
       routeros:

--- a/README.md
+++ b/README.md
@@ -78,10 +78,6 @@ After those environment variables are set you can run the tests with the followi
 make testacc
 ```
 
-> :warning:
->
-> For RouterOS versions `6.x` you have to set environment variable `LEGACY_BGP_SUPPORT="true"` before running tests.
-
 ### Testing without MikroTik hardware
 
 If you do not have MikroTik hardware or virtual machine with pre-installed RouterOS, you still have a way to run tests locally.

--- a/client/bgp_instance_test.go
+++ b/client/bgp_instance_test.go
@@ -29,7 +29,7 @@ var routerID string = "172.21.16.2"
 var routingTable string = ""
 
 func TestAddBgpInstanceAndDeleteBgpInstance(t *testing.T) {
-	SkipLegacyBgpIfUnsupported(t)
+	SkipIfRouterOSV7OrLater(t, sysResources)
 	c := NewClient(GetConfigFromEnv())
 
 	expectedBgpInstance := &BgpInstance{
@@ -65,7 +65,7 @@ func TestAddBgpInstanceAndDeleteBgpInstance(t *testing.T) {
 }
 
 func TestAddAndUpdateBgpInstanceWithOptionalFieldsAndDeleteBgpInstance(t *testing.T) {
-	SkipLegacyBgpIfUnsupported(t)
+	SkipIfRouterOSV7OrLater(t, sysResources)
 	c := NewClient(GetConfigFromEnv())
 
 	expectedBgpInstance := &BgpInstance{
@@ -116,7 +116,7 @@ func TestAddAndUpdateBgpInstanceWithOptionalFieldsAndDeleteBgpInstance(t *testin
 }
 
 func TestFindBgpInstance_onNonExistantBgpInstance(t *testing.T) {
-	SkipLegacyBgpIfUnsupported(t)
+	SkipIfRouterOSV7OrLater(t, sysResources)
 	c := NewClient(GetConfigFromEnv())
 
 	name := "bgp instance does not exist"

--- a/client/bgp_peer_test.go
+++ b/client/bgp_peer_test.go
@@ -18,7 +18,7 @@ var holdTime string = "3m"
 var nextHopChoice string = "default"
 
 func TestAddBgpPeerAndDeleteBgpPeer(t *testing.T) {
-	SkipLegacyBgpIfUnsupported(t)
+	SkipIfRouterOSV7OrLater(t, sysResources)
 	c := NewClient(GetConfigFromEnv())
 
 	instanceName := "peer-test"
@@ -62,7 +62,7 @@ func TestAddBgpPeerAndDeleteBgpPeer(t *testing.T) {
 }
 
 func TestAddAndUpdateBgpPeerWithOptionalFieldsAndDeleteBgpPeer(t *testing.T) {
-	SkipLegacyBgpIfUnsupported(t)
+	SkipIfRouterOSV7OrLater(t, sysResources)
 	c := NewClient(GetConfigFromEnv())
 
 	instanceName := "peer-update-test"
@@ -125,7 +125,7 @@ func TestAddAndUpdateBgpPeerWithOptionalFieldsAndDeleteBgpPeer(t *testing.T) {
 }
 
 func TestFindBgpPeer_onNonExistantBgpPeer(t *testing.T) {
-	SkipLegacyBgpIfUnsupported(t)
+	SkipIfRouterOSV7OrLater(t, sysResources)
 	c := NewClient(GetConfigFromEnv())
 
 	name := "bgp peer does not exist"

--- a/client/helpers.go
+++ b/client/helpers.go
@@ -1,32 +1,37 @@
 package client
 
 import (
-	"os"
+	"errors"
+	"fmt"
+	"strconv"
 	"testing"
 )
 
-func SkipLegacyBgpIfUnsupported(t *testing.T) {
-	if !IsLegacyBgpSupported() {
+func getRouterOSMajorVersion(systemResources SystemResources) (majorVersion int, err error) {
+	if len(systemResources.Version) == 0 {
+		return 0, errors.New("RouterOS system resources returned empty string")
+	}
+	majorVersion, err = strconv.Atoi(string(systemResources.Version[0]))
+	return
+}
+
+func SkipIfRouterOSV6OrEarlier(t *testing.T, systemResources SystemResources) {
+	majorVersion, err := getRouterOSMajorVersion(systemResources)
+	fmt.Printf("Deciding to skip: %v", systemResources)
+	if err != nil {
+		t.Errorf("failed to get the system resource major version: %v", err)
+	}
+	if majorVersion <= 6 {
 		t.Skip()
 	}
 }
 
-func IsLegacyBgpSupported() bool {
-	if os.Getenv("LEGACY_BGP_SUPPORT") == "true" {
-		return true
+func SkipIfRouterOSV7OrLater(t *testing.T, systemResources SystemResources) {
+	majorVersion, err := getRouterOSMajorVersion(systemResources)
+	if err != nil {
+		t.Errorf("failed to get the system resource major version: %v", err)
 	}
-	return false
-}
-
-func SkipInterfaceWireguardIfUnsupported(t *testing.T) {
-	if !IsInterfaceWireguardSupported() {
+	if majorVersion >= 7 {
 		t.Skip()
 	}
-}
-
-func IsInterfaceWireguardSupported() bool {
-	if os.Getenv("INTERFACE_WIREGUARD_SUPPORT") == "true" {
-		return true
-	}
-	return false
 }

--- a/client/interface_wireguard_test.go
+++ b/client/interface_wireguard_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestFindInterfaceWireguard_onNonExistantInterfaceWireguard(t *testing.T) {
-	SkipInterfaceWireguardIfUnsupported(t)
+	SkipIfRouterOSV6OrEarlier(t, sysResources)
 	c := NewClient(GetConfigFromEnv())
 
 	name := "Interface wireguard does not exist"
@@ -19,7 +19,7 @@ func TestFindInterfaceWireguard_onNonExistantInterfaceWireguard(t *testing.T) {
 }
 
 func TestAddFindDeleteInterfaceWireguard(t *testing.T) {
-	SkipInterfaceWireguardIfUnsupported(t)
+	SkipIfRouterOSV6OrEarlier(t, sysResources)
 	c := NewClient(GetConfigFromEnv())
 
 	name := "new_interface_wireguard"

--- a/client/ipv6_addr_test.go
+++ b/client/ipv6_addr_test.go
@@ -6,10 +6,7 @@ import (
 )
 
 func TestAddIpv6AddressAndDeleteIpv6Address(t *testing.T) {
-	if IsLegacyBgpSupported() {
-		t.Skip()
-	}
-
+	SkipIfRouterOSV6OrEarlier(t, sysResources)
 	c := NewClient(GetConfigFromEnv())
 
 	address := "1:1:1:1:1:1:1:1/64"

--- a/client/setup.go
+++ b/client/setup.go
@@ -1,0 +1,21 @@
+package client
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+func SetupAndTestMainExec(m *testing.M, sysResources *SystemResources) {
+	c := NewClient(GetConfigFromEnv())
+	s, err := c.GetSystemResources()
+
+	if err != nil {
+		fmt.Printf("Unable to perform test setup, failed with error: %v\n", err)
+		os.Exit(1)
+	}
+
+	*sysResources = *s
+
+	os.Exit(m.Run())
+}

--- a/client/setup_test.go
+++ b/client/setup_test.go
@@ -1,0 +1,11 @@
+package client
+
+import (
+	"testing"
+)
+
+var sysResources SystemResources
+
+func TestMain(m *testing.M) {
+	SetupAndTestMainExec(m, &sysResources)
+}

--- a/client/system_resources.go
+++ b/client/system_resources.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"log"
+
+	"github.com/ddelnano/terraform-provider-mikrotik/client/types"
+)
+
+type SystemResources struct {
+	Uptime  types.MikrotikDuration `mikrotik:"uptime"`
+	Version string                 `mikrotik:"version"`
+}
+
+func (d *SystemResources) ActionToCommand(action Action) string {
+	return map[Action]string{
+		Find: "/system/resource/print",
+	}[action]
+}
+
+func (client Mikrotik) GetSystemResources() (*SystemResources, error) {
+	c, err := client.getMikrotikClient()
+	if err != nil {
+		return nil, err
+	}
+	sysResources := &SystemResources{}
+	cmd := Marshal(sysResources.ActionToCommand(Find), sysResources)
+
+	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
+	r, err := c.RunArgs(cmd)
+
+	err = Unmarshal(*r, sysResources)
+	return sysResources, err
+}

--- a/client/system_resources_test.go
+++ b/client/system_resources_test.go
@@ -1,0 +1,24 @@
+package client
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetSystemResources(t *testing.T) {
+	c := NewClient(GetConfigFromEnv())
+	sysResources, err := c.GetSystemResources()
+
+	if err != nil {
+		t.Fatalf("failed to get system resources with error: %v", err)
+	}
+
+	if sysResources.Uptime <= 0 {
+		t.Fatalf("expected uptime > 0, instead received '%d'", sysResources.Uptime)
+	}
+
+	version := sysResources.Version
+	if strings.Index(version, "6") != 0 && strings.Index(version, "7") != 0 {
+		t.Errorf("expected RouterOS version to start with a '7' or '6' major release, instead received '%s'", version)
+	}
+}

--- a/mikrotik/acc_setup_test.go
+++ b/mikrotik/acc_setup_test.go
@@ -1,0 +1,13 @@
+package mikrotik
+
+import (
+	"testing"
+
+	"github.com/ddelnano/terraform-provider-mikrotik/client"
+)
+
+var sysResources client.SystemResources
+
+func TestMain(m *testing.M) {
+	client.SetupAndTestMainExec(m, &sysResources)
+}

--- a/mikrotik/resource_bgp_instance_test.go
+++ b/mikrotik/resource_bgp_instance_test.go
@@ -41,7 +41,7 @@ func TestAccMikrotikBgpInstance_create(t *testing.T) {
 }
 
 func TestAccMikrotikBgpInstance_createFailsOnRouterOSv7(t *testing.T) {
-	client.SkipIfRouterOSV7OrLater(t, sysResources)
+	client.SkipIfRouterOSV6OrEarlier(t, sysResources)
 
 	name := acctest.RandomWithPrefix("tf-acc-create")
 	routerId := internal.GetNewIpAddr()

--- a/mikrotik/resource_bgp_instance_test.go
+++ b/mikrotik/resource_bgp_instance_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestAccMikrotikBgpInstance_create(t *testing.T) {
-	client.SkipLegacyBgpIfUnsupported(t)
+	client.SkipIfRouterOSV7OrLater(t, sysResources)
 	name := acctest.RandomWithPrefix("tf-acc-create")
 	routerId := internal.GetNewIpAddr()
 	as := acctest.RandIntRange(1, 65535)
@@ -41,9 +41,7 @@ func TestAccMikrotikBgpInstance_create(t *testing.T) {
 }
 
 func TestAccMikrotikBgpInstance_createFailsOnRouterOSv7(t *testing.T) {
-	if client.IsLegacyBgpSupported() {
-		t.Skip()
-	}
+	client.SkipIfRouterOSV7OrLater(t, sysResources)
 
 	name := acctest.RandomWithPrefix("tf-acc-create")
 	routerId := internal.GetNewIpAddr()
@@ -63,7 +61,7 @@ func TestAccMikrotikBgpInstance_createFailsOnRouterOSv7(t *testing.T) {
 }
 
 func TestAccMikrotikBgpInstance_createAndPlanWithNonExistantBgpInstance(t *testing.T) {
-	client.SkipLegacyBgpIfUnsupported(t)
+	client.SkipIfRouterOSV7OrLater(t, sysResources)
 	name := acctest.RandomWithPrefix("tf-acc-create_with_plan")
 	routerId := internal.GetNewIpAddr()
 	as := acctest.RandIntRange(1, 65535)
@@ -89,7 +87,7 @@ func TestAccMikrotikBgpInstance_createAndPlanWithNonExistantBgpInstance(t *testi
 }
 
 func TestAccMikrotikBgpInstance_updateBgpInstance(t *testing.T) {
-	client.SkipLegacyBgpIfUnsupported(t)
+	client.SkipIfRouterOSV7OrLater(t, sysResources)
 	name := acctest.RandomWithPrefix("tf-acc-update")
 	routerId := internal.GetNewIpAddr()
 	updatedRouterId := internal.GetNewIpAddr()
@@ -142,7 +140,7 @@ func TestAccMikrotikBgpInstance_updateBgpInstance(t *testing.T) {
 }
 
 func TestAccMikrotikBgpInstance_import(t *testing.T) {
-	client.SkipLegacyBgpIfUnsupported(t)
+	client.SkipIfRouterOSV7OrLater(t, sysResources)
 	name := acctest.RandomWithPrefix("tf-acc-import")
 	routerId := internal.GetNewIpAddr()
 	as := acctest.RandIntRange(1, 65535)

--- a/mikrotik/resource_bgp_peer_test.go
+++ b/mikrotik/resource_bgp_peer_test.go
@@ -24,7 +24,7 @@ var updatedTTL string = "255"
 var updatedUseBfd string = "true"
 
 func TestAccMikrotikBgpPeer_create(t *testing.T) {
-	client.SkipLegacyBgpIfUnsupported(t)
+	client.SkipIfRouterOSV7OrLater(t, sysResources)
 	name := acctest.RandomWithPrefix("tf-acc-create")
 	remoteAs := acctest.RandIntRange(1, 65535)
 	remoteAddress, _ := acctest.RandIpAddress("192.168.0.0/24")
@@ -62,7 +62,7 @@ func TestAccMikrotikBgpPeer_create(t *testing.T) {
 }
 
 func TestAccMikrotikBgpPeer_createAndPlanWithNonExistantBgpPeer(t *testing.T) {
-	client.SkipLegacyBgpIfUnsupported(t)
+	client.SkipIfRouterOSV7OrLater(t, sysResources)
 	name := acctest.RandomWithPrefix("tf-acc-create_with_plan")
 	remoteAs := acctest.RandIntRange(1, 65535)
 	remoteAddress, _ := acctest.RandIpAddress("192.168.1.0/24")
@@ -101,7 +101,7 @@ func TestAccMikrotikBgpPeer_createAndPlanWithNonExistantBgpPeer(t *testing.T) {
 }
 
 func TestAccMikrotikBgpPeer_updateBgpPeer(t *testing.T) {
-	client.SkipLegacyBgpIfUnsupported(t)
+	client.SkipIfRouterOSV7OrLater(t, sysResources)
 	name := acctest.RandomWithPrefix("tf-acc-update")
 	remoteAs := acctest.RandIntRange(1, 65535)
 	remoteAddress, _ := acctest.RandIpAddress("192.168.3.0/24")
@@ -163,7 +163,7 @@ func TestAccMikrotikBgpPeer_updateBgpPeer(t *testing.T) {
 }
 
 func TestAccMikrotikBgpPeer_import(t *testing.T) {
-	client.SkipLegacyBgpIfUnsupported(t)
+	client.SkipIfRouterOSV7OrLater(t, sysResources)
 	name := acctest.RandomWithPrefix("tf-acc-import")
 	remoteAs := acctest.RandIntRange(1, 65535)
 	remoteAddress, _ := acctest.RandIpAddress("192.168.4.0/24")

--- a/mikrotik/resource_interface_wireguard_test.go
+++ b/mikrotik/resource_interface_wireguard_test.go
@@ -17,7 +17,7 @@ var origMTU int = 1420
 var updatedComment string = "new_comment"
 
 func TestAccMikrotikInterfaceWireguard_create(t *testing.T) {
-	client.SkipInterfaceWireguardIfUnsupported(t)
+	client.SkipIfRouterOSV6OrEarlier(t, sysResources)
 	name := acctest.RandomWithPrefix("tf-acc-create")
 
 	resourceName := "mikrotik_interface_wireguard.bar"
@@ -41,7 +41,7 @@ func TestAccMikrotikInterfaceWireguard_create(t *testing.T) {
 }
 
 func TestAccMikrotikInterfaceWireguard_updatedComment(t *testing.T) {
-	client.SkipInterfaceWireguardIfUnsupported(t)
+	client.SkipIfRouterOSV6OrEarlier(t, sysResources)
 	name := acctest.RandomWithPrefix("tf-acc-update-comment")
 
 	resourceName := "mikrotik_interface_wireguard.bar"
@@ -69,7 +69,7 @@ func TestAccMikrotikInterfaceWireguard_updatedComment(t *testing.T) {
 }
 
 func TestAccMikrotikInterfaceWireguard_import(t *testing.T) {
-	client.SkipInterfaceWireguardIfUnsupported(t)
+	client.SkipIfRouterOSV6OrEarlier(t, sysResources)
 	name := acctest.RandomWithPrefix("tf-acc-import")
 
 	resourceName := "mikrotik_interface_wireguard.bar"

--- a/mikrotik/resource_ipv6_address_test.go
+++ b/mikrotik/resource_ipv6_address_test.go
@@ -12,9 +12,7 @@ import (
 )
 
 func TestAccMikrotikResourceIpv6Address_create(t *testing.T) {
-	if client.IsLegacyBgpSupported() {
-		t.Skip()
-	}
+	client.SkipIfRouterOSV6OrEarlier(t, sysResources)
 
 	ipv6Addr := internal.GetNewIpv6Addr() + "/64"
 	ifName := "ether1"
@@ -41,9 +39,7 @@ func TestAccMikrotikResourceIpv6Address_create(t *testing.T) {
 }
 
 func TestAccMikrotikResourceIpv6Address_updateAddr(t *testing.T) {
-	if client.IsLegacyBgpSupported() {
-		t.Skip()
-	}
+	client.SkipIfRouterOSV6OrEarlier(t, sysResources)
 
 	ipAddr := internal.GetNewIpv6Addr() + "/64"
 	updatedIpv6Addr := internal.GetNewIpv6Addr() + "/64"


### PR DESCRIPTION
Prior to this change, we were using "legacy bgp support" or "wireguard support" environment variables as a proxy for RouterOS version detection. This change adds the necessary client support to dynamically determine what RouterOS version is in use and rely on that exclusively for all of our feature opt out/in.

This removes the need for providing environment variables to enforce this intent and fits better with what we wanted to originally express (whether a feature was supported on a given version or not).