### PR TITLE
add Terraform wrapper types to generate docs with default value

### DIFF
--- a/mikrotik/internal/types/defaultaware/bool.go
+++ b/mikrotik/internal/types/defaultaware/bool.go
@@ -1,0 +1,34 @@
+package defaultaware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+)
+
+// BoolAttribute creates a wrapper for schema.BoolAttribute object and generates documentation with default value.
+func BoolAttribute(wrapped schema.BoolAttribute) schema.Attribute {
+	return boolWrapper{wrapped}
+}
+
+func (w boolWrapper) GetDescription() string {
+	desc := w.BoolAttribute.GetDescription()
+	if w.Default == nil {
+		return desc
+	}
+
+	resp := defaults.BoolResponse{}
+	w.Default.DefaultBool(context.TODO(), defaults.BoolRequest{}, &resp)
+	defaultValue := resp.PlanValue.ValueBool()
+	desc = fmt.Sprintf("%s Default: `%t`.", desc, defaultValue)
+
+	return desc
+}
+
+type boolWrapper struct {
+	schema.BoolAttribute
+}
+
+var _ schema.Attribute = &boolWrapper{}

--- a/mikrotik/internal/types/defaultaware/bool_test.go
+++ b/mikrotik/internal/types/defaultaware/bool_test.go
@@ -1,0 +1,47 @@
+package defaultaware
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoolWrapper(t *testing.T) {
+	testCases := []struct {
+		name           string
+		description    string
+		defaultValue   defaults.Bool
+		expectedResult string
+	}{
+		{
+			name:           "no default value",
+			description:    "Attribute description.",
+			expectedResult: "Attribute description.",
+		},
+		{
+			name:           "true default value",
+			description:    "Attribute description.",
+			defaultValue:   booldefault.StaticBool(true),
+			expectedResult: "Attribute description. Default: `true`.",
+		}, {
+			name:           "false default value",
+			description:    "Attribute description.",
+			defaultValue:   booldefault.StaticBool(false),
+			expectedResult: "Attribute description. Default: `false`.",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			attr := BoolAttribute(
+				schema.BoolAttribute{
+					Description: tc.description,
+					Default:     tc.defaultValue,
+				},
+			)
+			require.Equal(t, tc.expectedResult, attr.GetDescription())
+		})
+	}
+}

--- a/mikrotik/internal/types/defaultaware/int64.go
+++ b/mikrotik/internal/types/defaultaware/int64.go
@@ -1,0 +1,34 @@
+package defaultaware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+)
+
+// Int64Attribute creates a wrapper for schema.Int64Attribute object and generates documentation with default value.
+func Int64Attribute(wrapped schema.Int64Attribute) schema.Attribute {
+	return int64Wrapper{wrapped}
+}
+
+func (w int64Wrapper) GetDescription() string {
+	desc := w.Int64Attribute.GetDescription()
+	if w.Default == nil {
+		return desc
+	}
+
+	resp := defaults.Int64Response{}
+	w.Default.DefaultInt64(context.TODO(), defaults.Int64Request{}, &resp)
+	defaultValue := resp.PlanValue.ValueInt64()
+	desc = fmt.Sprintf("%s Default: `%d`.", desc, defaultValue)
+
+	return desc
+}
+
+type int64Wrapper struct {
+	schema.Int64Attribute
+}
+
+var _ schema.Attribute = &int64Wrapper{}

--- a/mikrotik/internal/types/defaultaware/int64_test.go
+++ b/mikrotik/internal/types/defaultaware/int64_test.go
@@ -1,0 +1,47 @@
+package defaultaware
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInt64Wrapper(t *testing.T) {
+	testCases := []struct {
+		name           string
+		description    string
+		defaultValue   defaults.Int64
+		expectedResult string
+	}{
+		{
+			name:           "no default value",
+			description:    "Attribute description.",
+			expectedResult: "Attribute description.",
+		},
+		{
+			name:           "with default value",
+			description:    "Attribute description.",
+			defaultValue:   int64default.StaticInt64(2),
+			expectedResult: "Attribute description. Default: `2`.",
+		}, {
+			name:           "with zero default value",
+			description:    "Attribute description.",
+			defaultValue:   int64default.StaticInt64(0),
+			expectedResult: "Attribute description. Default: `0`.",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			attr := Int64Attribute(
+				schema.Int64Attribute{
+					Description: tc.description,
+					Default:     tc.defaultValue,
+				},
+			)
+			require.Equal(t, tc.expectedResult, attr.GetDescription())
+		})
+	}
+}

--- a/mikrotik/internal/types/defaultaware/string.go
+++ b/mikrotik/internal/types/defaultaware/string.go
@@ -1,0 +1,37 @@
+package defaultaware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+)
+
+// StringAttribute creates a wrapper for schema.StringAttribute object and generates documentation with default value.
+func StringAttribute(wrapped schema.StringAttribute) schema.Attribute {
+	return stringWrapper{wrapped}
+}
+
+func (w stringWrapper) GetDescription() string {
+	desc := w.StringAttribute.GetDescription()
+	if w.Default == nil {
+		return desc
+	}
+
+	resp := defaults.StringResponse{}
+	w.Default.DefaultString(context.TODO(), defaults.StringRequest{}, &resp)
+	defaultValue := resp.PlanValue.ValueString()
+	if defaultValue == "" {
+		defaultValue = `""`
+	}
+	desc = fmt.Sprintf("%s Default: `%s`.", desc, defaultValue)
+
+	return desc
+}
+
+type stringWrapper struct {
+	schema.StringAttribute
+}
+
+var _ schema.Attribute = &stringWrapper{}

--- a/mikrotik/internal/types/defaultaware/string_test.go
+++ b/mikrotik/internal/types/defaultaware/string_test.go
@@ -1,0 +1,47 @@
+package defaultaware
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/defaults"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStringWrapper(t *testing.T) {
+	testCases := []struct {
+		name           string
+		description    string
+		defaultValue   defaults.String
+		expectedResult string
+	}{
+		{
+			name:           "no default value",
+			description:    "Attribute description.",
+			expectedResult: "Attribute description.",
+		},
+		{
+			name:           "with default value",
+			description:    "Attribute description.",
+			defaultValue:   stringdefault.StaticString("some value"),
+			expectedResult: "Attribute description. Default: `some value`.",
+		}, {
+			name:           "with empty string default value",
+			description:    "Attribute description.",
+			defaultValue:   stringdefault.StaticString(""),
+			expectedResult: "Attribute description. Default: `\"\"`.",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			attr := StringAttribute(
+				schema.StringAttribute{
+					Description: tc.description,
+					Default:     tc.defaultValue,
+				},
+			)
+			require.Equal(t, tc.expectedResult, attr.GetDescription())
+		})
+	}
+}


### PR DESCRIPTION
This PR introduces wrapper types to generate Terraform docs with default value.
It is a drop-in replacement implemented as function.
To enable this feature, just wrap attribute in schema with proper typed wrapper:
```go
"address_pool": defaultaware.StringAttribute(
	schema.StringAttribute{
		Optional:    true,
		Computed:    true,
		Default:     stringdefault.StaticString("static-only"),
		Description: "IP pool, from which to take IP addresses for the clients. If set to static-only, then only the clients that have a static lease (added in lease submenu) will be allowed.",
	},
),
```
and next run of `make generate` will generate documentation with `Default: ....` suffix.