### PR TITLE
support case-insensitive IPAddress ID while importing

### DIFF
--- a/mikrotik/resource_firewall_filter.go
+++ b/mikrotik/resource_firewall_filter.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ddelnano/terraform-provider-mikrotik/client"
 	"github.com/ddelnano/terraform-provider-mikrotik/mikrotik/internal/types/defaultaware"
+	"github.com/ddelnano/terraform-provider-mikrotik/mikrotik/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -141,7 +142,7 @@ func (r *firewallFilterRule) Delete(ctx context.Context, req resource.DeleteRequ
 
 func (r *firewallFilterRule) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// Retrieve import ID and save to id attribute
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	utils.ImportUppercaseWrapper(resource.ImportStatePassthroughID)(ctx, path.Root("id"), req, resp)
 }
 
 type firewallFilterRuleModel struct {

--- a/mikrotik/resource_interface_list_member.go
+++ b/mikrotik/resource_interface_list_member.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ddelnano/terraform-provider-mikrotik/client"
+	"github.com/ddelnano/terraform-provider-mikrotik/mikrotik/internal/utils"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -96,7 +97,7 @@ func (r *interfaceListMember) Delete(ctx context.Context, req resource.DeleteReq
 
 func (r *interfaceListMember) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// Retrieve import ID and save to id attribute
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	utils.ImportUppercaseWrapper(resource.ImportStatePassthroughID)(ctx, path.Root("id"), req, resp)
 }
 
 type interfaceListMemberModel struct {

--- a/mikrotik/resource_ip_address.go
+++ b/mikrotik/resource_ip_address.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/ddelnano/terraform-provider-mikrotik/client"
+	"github.com/ddelnano/terraform-provider-mikrotik/mikrotik/internal/utils"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -114,7 +115,7 @@ func (r *ipAddress) Delete(ctx context.Context, req resource.DeleteRequest, resp
 
 func (r *ipAddress) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// Retrieve import ID and save to id attribute
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	utils.ImportUppercaseWrapper(resource.ImportStatePassthroughID)(ctx, path.Root("id"), req, resp)
 }
 
 type ipAddressModel struct {

--- a/mikrotik/resource_pool.go
+++ b/mikrotik/resource_pool.go
@@ -148,7 +148,7 @@ func (r *pool) Delete(ctx context.Context, req resource.DeleteRequest, resp *res
 
 func (r *pool) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	// Retrieve import ID and save to id attribute
-	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+	utils.ImportUppercaseWrapper(resource.ImportStatePassthroughID)(ctx, path.Root("id"), req, resp)
 }
 
 type poolModel struct {


### PR DESCRIPTION
This PR allows `import id` for resource to be in lowercase.

Both commands will act in the same way:
```shell
$ terraform import mikrotik_ip_address.this '*3e'
```
and
```shell
$ terraform import mikrotik_ip_address.this '*3E'
```