### PR TITLE
make copyStruct() function case-insensitive while searching for fields in structs

### DIFF
--- a/mikrotik/internal/utils/struct_copy_test.go
+++ b/mikrotik/internal/utils/struct_copy_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"context"
 	"testing"
 
 	"github.com/ddelnano/terraform-provider-mikrotik/client"
@@ -334,7 +335,7 @@ func TestCopyStruct(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := copyStruct(tc.src, tc.dest)
+			err := copyStruct(context.TODO(), tc.src, tc.dest)
 			if tc.expectError {
 				require.Error(t, err)
 				return
@@ -395,7 +396,7 @@ func TestCopyTerraformToMikrotik(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := TerraformModelToMikrotikStruct(tc.src, tc.dest)
+			err := TerraformModelToMikrotikStruct(context.TODO(), tc.src, tc.dest)
 			if tc.expectError {
 				require.Error(t, err)
 				return
@@ -469,7 +470,7 @@ func TestCopyMikrotikToTerraform(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := MikrotikStructToTerraformModel(tc.src, tc.dest)
+			err := MikrotikStructToTerraformModel(context.TODO(), tc.src, tc.dest)
 			if tc.expectError {
 				require.Error(t, err)
 				return

--- a/mikrotik/internal/utils/struct_copy_test.go
+++ b/mikrotik/internal/utils/struct_copy_test.go
@@ -80,6 +80,36 @@ func TestCopyStruct(t *testing.T) {
 			},
 		},
 		{
+			name: "different case",
+			src: struct {
+				NAME        string
+				SourceField int
+				itEMS       []string
+			}{
+				NAME:        "src field name",
+				SourceField: 10,
+				itEMS:       []string{"one", "two"},
+			},
+			dest: &struct {
+				Name             string
+				DestinationField int
+				Items            []string
+			}{
+				Name:             "dest field name",
+				DestinationField: 20,
+				Items:            []string{"one", "two", "three"},
+			},
+			expected: &struct {
+				Name             string
+				DestinationField int
+				Items            []string
+			}{
+				Name:             "src field name",
+				DestinationField: 20,
+				Items:            []string{"one", "two", "three"},
+			},
+		},
+		{
 			name: "custom field to regular",
 			src: client.BridgeVlan{
 				Id:       "identifier",

--- a/mikrotik/resource_generic_crud_operations.go
+++ b/mikrotik/resource_generic_crud_operations.go
@@ -26,7 +26,7 @@ func GenericCreateResource(terraformModel interface{}, mikrotikModel client.Reso
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		if err := utils.TerraformModelToMikrotikStruct(terraformModel, mikrotikModel); err != nil {
+		if err := utils.TerraformModelToMikrotikStruct(ctx, terraformModel, mikrotikModel); err != nil {
 			resp.Diagnostics.AddError("Cannot copy model: Terraform -> MikroTik", err.Error())
 			return
 		}
@@ -37,7 +37,7 @@ func GenericCreateResource(terraformModel interface{}, mikrotikModel client.Reso
 			return
 		}
 
-		if err := utils.MikrotikStructToTerraformModel(created, terraformModel); err != nil {
+		if err := utils.MikrotikStructToTerraformModel(ctx, created, terraformModel); err != nil {
 			resp.Diagnostics.AddError("Cannot copy model: MikroTik -> Terraform", err.Error())
 			return
 		}
@@ -56,7 +56,7 @@ func GenericReadResource(terraformModel interface{}, mikrotikModel client.Resour
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		if err := utils.TerraformModelToMikrotikStruct(terraformModel, mikrotikModel); err != nil {
+		if err := utils.TerraformModelToMikrotikStruct(ctx, terraformModel, mikrotikModel); err != nil {
 			resp.Diagnostics.AddError("Cannot copy model: Terraform -> MikroTik", err.Error())
 			return
 		}
@@ -73,7 +73,7 @@ func GenericReadResource(terraformModel interface{}, mikrotikModel client.Resour
 			)
 			return
 		}
-		if err := utils.MikrotikStructToTerraformModel(resource, terraformModel); err != nil {
+		if err := utils.MikrotikStructToTerraformModel(ctx, resource, terraformModel); err != nil {
 			resp.Diagnostics.AddError("Cannot copy model: MikroTik -> Terraform", err.Error())
 			return
 		}
@@ -92,7 +92,7 @@ func GenericUpdateResource(terraformModel interface{}, mikrotikModel client.Reso
 		if resp.Diagnostics.HasError() {
 			return
 		}
-		if err := utils.TerraformModelToMikrotikStruct(terraformModel, mikrotikModel); err != nil {
+		if err := utils.TerraformModelToMikrotikStruct(ctx, terraformModel, mikrotikModel); err != nil {
 			resp.Diagnostics.AddError("Cannot copy model: Terraform -> MikroTik", err.Error())
 			return
 		}
@@ -101,7 +101,7 @@ func GenericUpdateResource(terraformModel interface{}, mikrotikModel client.Reso
 			resp.Diagnostics.AddError("Update failed", err.Error())
 			return
 		}
-		if err := utils.MikrotikStructToTerraformModel(updated, terraformModel); err != nil {
+		if err := utils.MikrotikStructToTerraformModel(ctx, updated, terraformModel); err != nil {
 			resp.Diagnostics.AddError("Cannot copy model: MikroTik -> Terraform", err.Error())
 			return
 		}
@@ -118,7 +118,7 @@ func GenericDeleteResource(terraformModel interface{}, mikrotikModel client.Reso
 			return
 		}
 
-		if err := utils.TerraformModelToMikrotikStruct(terraformModel, mikrotikModel); err != nil {
+		if err := utils.TerraformModelToMikrotikStruct(ctx, terraformModel, mikrotikModel); err != nil {
 			resp.Diagnostics.AddError("Cannot copy model: Terraform -> MikroTik", err.Error())
 			return
 		}

--- a/mikrotik/resource_pool.go
+++ b/mikrotik/resource_pool.go
@@ -122,7 +122,7 @@ func (r *pool) Update(ctx context.Context, req resource.UpdateRequest, resp *res
 		terraformModel.NextPool = tftypes.StringValue("none")
 	}
 
-	if err := utils.TerraformModelToMikrotikStruct(&terraformModel, &mikrotikModel); err != nil {
+	if err := utils.TerraformModelToMikrotikStruct(ctx, &terraformModel, &mikrotikModel); err != nil {
 		resp.Diagnostics.AddError("Cannot copy model: Terraform -> MikroTik", err.Error())
 		return
 	}
@@ -131,7 +131,7 @@ func (r *pool) Update(ctx context.Context, req resource.UpdateRequest, resp *res
 		resp.Diagnostics.AddError("Update failed", err.Error())
 		return
 	}
-	if err := utils.MikrotikStructToTerraformModel(updated, &terraformModel); err != nil {
+	if err := utils.MikrotikStructToTerraformModel(ctx, updated, &terraformModel); err != nil {
 		resp.Diagnostics.AddError("Cannot copy model: MikroTik -> Terraform", err.Error())
 		return
 	}


### PR DESCRIPTION
Closes #213 