### PR TITLE
fix: do not set default value for netmask in mikrotik_dhcp_server_network

### DIFF
--- a/docs/resources/dhcp_server_network.md
+++ b/docs/resources/dhcp_server_network.md
@@ -21,7 +21,7 @@ resource "mikrotik_dhcp_server_network" "default" {
 - `comment` (String)
 - `dns_server` (String) The DHCP client will use these as the default DNS servers.
 - `gateway` (String) The default gateway to be used by DHCP Client. Default: `0.0.0.0`.
-- `netmask` (String) The actual network mask to be used by DHCP client. If set to '0' - netmask from network address will be used. Default: `0`.
+- `netmask` (String) The actual network mask to be used by DHCP client. If set to '0' - netmask from network address will be used.
 
 ### Read-Only
 

--- a/mikrotik/resource_dhcp_server_network.go
+++ b/mikrotik/resource_dhcp_server_network.go
@@ -68,7 +68,6 @@ func (s *dhcpServerNetwork) Schema(_ context.Context, _ resource.SchemaRequest, 
 			"netmask": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
-				Default:     stringdefault.StaticString("0"),
 				Description: "The actual network mask to be used by DHCP client. If set to '0' - netmask from network address will be used.",
 			},
 			"gateway": schema.StringAttribute{

--- a/mikrotik/resource_dhcp_server_network_test.go
+++ b/mikrotik/resource_dhcp_server_network_test.go
@@ -10,9 +10,7 @@ import (
 )
 
 func TestDhcpServerNetwork_basic(t *testing.T) {
-
 	resourceName := "mikrotik_dhcp_server_network.testacc"
-
 	netmask := "24"
 	address := "10.10.10.0/" + netmask
 	gateway := "10.10.10.2"
@@ -44,6 +42,53 @@ func TestDhcpServerNetwork_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "gateway", gateway),
 					resource.TestCheckResourceAttr(resourceName, "dns_server", dnsServerUpdated),
 					resource.TestCheckResourceAttr(resourceName, "comment", comment),
+				),
+			},
+		},
+	})
+}
+
+func TestDhcpServerNetwork_incompleteFieldsSet(t *testing.T) {
+	resourceName := "mikrotik_dhcp_server_network.testacc"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckDhcpServerNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: `
+					resource mikrotik_dhcp_server_network "testacc" {
+						address    = "10.10.10.0/24"
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDhcpServerNetworkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "address", "10.10.10.0/24"),
+				),
+			},
+			{
+				Config: `
+					resource mikrotik_dhcp_server_network "testacc" {
+						address    = "10.10.10.0/24"
+						netmask    = "24"
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDhcpServerNetworkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "address", "10.10.10.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "netmask", "24"),
+				),
+			},
+			{
+				Config: `
+					resource mikrotik_dhcp_server_network "testacc" {
+						address    = "10.10.10.0/24"
+					}
+				`,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccDhcpServerNetworkExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "address", "10.10.10.0/24"),
+					resource.TestCheckResourceAttr(resourceName, "netmask", "24"),
 				),
 			},
 		},


### PR DESCRIPTION
This PR removes default value for `netmask` in mikrotik_dhcp_server_network.
The root cause of the issue is that `netmask` has `integer` type in RouterOS but in the provider it is `string`, hence empty value in RouterOS (`0` zero) is not the same as empty value in provider (`""` empty string).

Resolves #219 