### PR TITLE
fix: use Duration type for PersistentKeepalive field in InterfaceWireguardPeer

### DIFF
--- a/client/interface_wireguard_peer.go
+++ b/client/interface_wireguard_peer.go
@@ -1,20 +1,21 @@
 package client
 
 import (
+	"github.com/ddelnano/terraform-provider-mikrotik/client/types"
 	"github.com/go-routeros/routeros"
 )
 
 type InterfaceWireguardPeer struct {
-	Id                  string `mikrotik:".id"`
-	AllowedAddress      string `mikrotik:"allowed-address"`
-	Comment             string `mikrotik:"comment"`
-	Disabled            bool   `mikrotik:"disabled"`
-	EndpointAddress     string `mikrotik:"endpoint-address"`
-	EndpointPort        int64  `mikrotik:"endpoint-port"`
-	Interface           string `mikrotik:"interface"`
-	PersistentKeepalive int64  `mikrotik:"persistent-keepalive"`
-	PresharedKey        string `mikrotik:"preshared-key"`
-	PublicKey           string `mikrotik:"public-key"`
+	Id                  string                 `mikrotik:".id"`
+	AllowedAddress      string                 `mikrotik:"allowed-address"`
+	Comment             string                 `mikrotik:"comment"`
+	Disabled            bool                   `mikrotik:"disabled"`
+	EndpointAddress     string                 `mikrotik:"endpoint-address"`
+	EndpointPort        int64                  `mikrotik:"endpoint-port"`
+	Interface           string                 `mikrotik:"interface"`
+	PersistentKeepalive types.MikrotikDuration `mikrotik:"persistent-keepalive"`
+	PresharedKey        string                 `mikrotik:"preshared-key"`
+	PublicKey           string                 `mikrotik:"public-key"`
 }
 
 func (i *InterfaceWireguardPeer) ActionToCommand(action Action) string {

--- a/mikrotik/resource_interface_wireguard_peer_test.go
+++ b/mikrotik/resource_interface_wireguard_peer_test.go
@@ -112,11 +112,13 @@ func TestAccMikrotikInterfaceWireguardPeer_update(t *testing.T) {
 					public_key = "%s"
 					allowed_address = "%s"
 					endpoint_port = 13251
+					persistent_keepalive = 3602
 				}`, interfaceName, publicKey, origAllowedAddress),
 
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccInterfaceWireguardPeerExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "interface", interfaceName),
+					resource.TestCheckResourceAttr(resourceName, "persistent_keepalive", "3602"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes #221 

In MikroTik documentation, the `persistent_keepalive` [is defined](https://help.mikrotik.com/docs/display/ROS/WireGuard#WireGuard-Peers) as `Integer: A seconds interval, between 1 and 65535 inclusive.`

In fact, after client sets it, in all subsequent reads this field becomes a duration:
| Set value | Read value |
|:---------:|:-----------:|
| 20 | 20s |
| 123 | 2m3s |
| 3602 | 1h2s |


This PR changes `PersistentKeepalive` field type to our internal Duration type that can handle such normalizations.