### PR TITLE
fix script.owner attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 terraform-provider-mikrotik
 dist/
 vendor
+.vscode/

--- a/client/script.go
+++ b/client/script.go
@@ -8,7 +8,7 @@ import (
 type Script struct {
 	Id                     string             `mikrotik:".id" codegen:"id,deleteID"`
 	Name                   string             `mikrotik:"name" codegen:"name,required,mikrotikID"`
-	Owner                  string             `mikrotik:"owner" codegen:"owner,required"`
+	Owner                  string             `mikrotik:"owner,readonly" codegen:"owner,computed"`
 	Policy                 types.MikrotikList `mikrotik:"policy" codegen:"policy,required"`
 	DontRequirePermissions bool               `mikrotik:"dont-require-permissions" codegen:"dont_require_permissions"`
 	Source                 string             `mikrotik:"source" codegen:"source,required"`

--- a/docs/resources/script.md
+++ b/docs/resources/script.md
@@ -22,7 +22,6 @@ EOF
 ### Required
 
 - `name` (String) The name of script.
-- `owner` (String) The owner of the script.
 - `policy` (List of String) What permissions the script has. This must be one of the following: ftp, reboot, read, write, policy, test, password, sniff, sensitive, romon.
 - `source` (String) The source code of the script. See the [MikroTik docs](https://wiki.mikrotik.com/wiki/Manual:Scripting) for the scripting language.
 
@@ -33,6 +32,7 @@ EOF
 ### Read-Only
 
 - `id` (String) ID of this resource.
+- `owner` (String) The owner of the script.
 
 ## Import
 Import is supported using the following syntax:

--- a/mikrotik/resource_script.go
+++ b/mikrotik/resource_script.go
@@ -62,10 +62,6 @@ func (s *script) Schema(_ context.Context, _ resource.SchemaRequest, resp *resou
 				},
 				Description: "The name of script.",
 			},
-			"owner": schema.StringAttribute{
-				Required:    true,
-				Description: "The owner of the script.",
-			},
 			"policy": schema.ListAttribute{
 				Required:    true,
 				ElementType: tftypes.StringType,
@@ -80,6 +76,10 @@ func (s *script) Schema(_ context.Context, _ resource.SchemaRequest, resp *resou
 			"source": schema.StringAttribute{
 				Required:    true,
 				Description: "The source code of the script. See the [MikroTik docs](https://wiki.mikrotik.com/wiki/Manual:Scripting) for the scripting language.",
+			},
+			"owner": schema.StringAttribute{
+				Computed:    true,
+				Description: "The owner of the script.",
 			},
 		},
 	}

--- a/mikrotik/resource_script_test.go
+++ b/mikrotik/resource_script_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-// TODO: Add dependent resources for owner
-var defaultOwner = "admin"
 var defaultSource = ":put testing"
 var defaultPolicies = []string{"ftp", "reboot"}
 
@@ -56,32 +54,6 @@ func TestAccMikrotikScript_updateSource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccScriptExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "source", updatedSource)),
-			},
-		},
-	})
-}
-
-func TestAccMikrotikScript_updateOwner(t *testing.T) {
-	name := acctest.RandomWithPrefix("tf-acc-update-owner")
-	updatedOwner := "prometheus"
-
-	resourceName := "mikrotik_script.bar"
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV5ProviderFactories: testAccProtoV5ProviderFactories,
-		CheckDestroy:             testAccCheckMikrotikScriptDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccScriptRecord(name, defaultSource, defaultPolicies),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccScriptExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "owner", defaultOwner)),
-			},
-			{
-				Config: testAccScriptRecord(name, defaultSource, defaultPolicies),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccScriptExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "owner", updatedOwner)),
 			},
 		},
 	})

--- a/mikrotik/resource_script_test.go
+++ b/mikrotik/resource_script_test.go
@@ -26,7 +26,7 @@ func TestAccMikrotikScript_create(t *testing.T) {
 		CheckDestroy:             testAccCheckMikrotikScriptDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScriptRecord(name, defaultOwner, defaultSource, defaultPolicies),
+				Config: testAccScriptRecord(name, defaultSource, defaultPolicies),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccScriptExists(resourceName),
 					resource.TestCheckResourceAttrSet(resourceName, "id")),
@@ -46,13 +46,13 @@ func TestAccMikrotikScript_updateSource(t *testing.T) {
 		CheckDestroy:             testAccCheckMikrotikScriptDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScriptRecord(name, defaultOwner, defaultSource, defaultPolicies),
+				Config: testAccScriptRecord(name, defaultSource, defaultPolicies),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccScriptExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "source", defaultSource)),
 			},
 			{
-				Config: testAccScriptRecord(name, defaultOwner, updatedSource, defaultPolicies),
+				Config: testAccScriptRecord(name, updatedSource, defaultPolicies),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccScriptExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "source", updatedSource)),
@@ -72,13 +72,13 @@ func TestAccMikrotikScript_updateOwner(t *testing.T) {
 		CheckDestroy:             testAccCheckMikrotikScriptDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScriptRecord(name, defaultOwner, defaultSource, defaultPolicies),
+				Config: testAccScriptRecord(name, defaultSource, defaultPolicies),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccScriptExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "owner", defaultOwner)),
 			},
 			{
-				Config: testAccScriptRecord(name, updatedOwner, defaultSource, defaultPolicies),
+				Config: testAccScriptRecord(name, defaultSource, defaultPolicies),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccScriptExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "owner", updatedOwner)),
@@ -97,13 +97,13 @@ func TestAccMikrotikScript_updateDontReqPerms(t *testing.T) {
 		CheckDestroy:             testAccCheckMikrotikScriptDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScriptRecord(name, defaultOwner, defaultSource, defaultPolicies),
+				Config: testAccScriptRecord(name, defaultSource, defaultPolicies),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccScriptExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "dont_require_permissions", "false")),
 			},
 			{
-				Config: testAccScriptRecordWithPerms(name, defaultOwner, defaultSource, defaultPolicies, true),
+				Config: testAccScriptRecordWithPerms(name, defaultSource, defaultPolicies, true),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccScriptExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "dont_require_permissions", "true")),
@@ -123,7 +123,7 @@ func TestAccMikrotikScript_updatePolicies(t *testing.T) {
 		CheckDestroy:             testAccCheckMikrotikScriptDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScriptRecord(name, defaultOwner, defaultSource, defaultPolicies),
+				Config: testAccScriptRecord(name, defaultSource, defaultPolicies),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccScriptExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "policy.#", "2"),
@@ -131,7 +131,7 @@ func TestAccMikrotikScript_updatePolicies(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "policy.1", defaultPolicies[1])),
 			},
 			{
-				Config: testAccScriptRecord(name, defaultOwner, defaultSource, updatedPolicies),
+				Config: testAccScriptRecord(name, defaultSource, updatedPolicies),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccScriptExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "policy.#", "1"),
@@ -151,10 +151,11 @@ func TestAccMikrotikScript_import(t *testing.T) {
 		CheckDestroy:             testAccCheckMikrotikScriptDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccScriptRecord(name, defaultOwner, defaultSource, defaultPolicies),
+				Config: testAccScriptRecord(name, defaultSource, defaultPolicies),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccScriptExists(resourceName),
-					resource.TestCheckResourceAttr(resourceName, "dont_require_permissions", "false")),
+					resource.TestCheckResourceAttr(resourceName, "dont_require_permissions", "false"),
+					resource.TestCheckResourceAttr(resourceName, "owner", "admin")),
 			},
 			{
 				ResourceName:      resourceName,
@@ -166,27 +167,25 @@ func TestAccMikrotikScript_import(t *testing.T) {
 	})
 }
 
-func testAccScriptRecord(name, owner, source string, policies []string) string {
+func testAccScriptRecord(name, source string, policies []string) string {
 	return fmt.Sprintf(`
 resource "mikrotik_script" "bar" {
     name = "%s"
-    owner = "%s"
     source = "%s"
     policy = ["%s"]
 }
-`, name, owner, source, strings.Join(policies, "\",\""))
+`, name, source, strings.Join(policies, "\",\""))
 }
 
-func testAccScriptRecordWithPerms(name, owner, source string, policies []string, dontRequirePermissions bool) string {
+func testAccScriptRecordWithPerms(name, source string, policies []string, dontRequirePermissions bool) string {
 	return fmt.Sprintf(`
 resource "mikrotik_script" "bar" {
     name = "%s"
-    owner = "%s"
     source = "%s"
     policy = ["%s"]
     dont_require_permissions = %t
 }
-`, name, owner, source, strings.Join(policies, "\",\""), dontRequirePermissions)
+`, name, source, strings.Join(policies, "\",\""), dontRequirePermissions)
 }
 
 func testAccCheckMikrotikScriptDestroy(s *terraform.State) error {


### PR DESCRIPTION
The `owner` attribute is readonly in RouterOS.
See [documentation](https://help.mikrotik.com/docs/spaces/ROS/pages/47579229/Scripting#Scripting-Scriptrepository)