### PR TITLE
improve stability of testing setup

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Run linters
         run: make lint
 
+      - name: Wait until RouterOS container is ready
+        run: ./bin/wait-for-routeros.sh
+
       - name: Run provider tests
         run: make testacc
         env:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,7 +44,7 @@ jobs:
         run: make lint
 
       - name: Wait until RouterOS container is ready
-        run: ./bin/wait-for-routeros.sh
+        run: ./bin/wait-for-routeros.sh 8080
 
       - name: Run provider tests
         run: make testacc
@@ -67,7 +67,7 @@ jobs:
         image: mnazarenko/docker-routeros:${{ matrix.routeros }}
         ports:
           - 8728:8728
-        volumes:
-          - /dev/net/tun:/dev/net/tun
+          - 8080:80
         options: >-
           --cap-add=NET_ADMIN
+          --device=/dev/net/tun

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -44,7 +44,7 @@ jobs:
         run: make lint
 
       - name: Wait until RouterOS container is ready
-        run: ./bin/wait-for-routeros.sh 8080
+        run: ./bin/wait-for-routeros.sh 127.0.0.1 8080
 
       - name: Run provider tests
         run: make testacc

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ lint: lint-client lint-provider
 
 test: lint testclient testacc
 
-testclient: wait-for-routeros
+testclient:
 	cd client; go test $(TEST) -race -v -count 1
 
-testacc: wait-for-routeros
+testacc:
 	TF_ACC=1 $(TF_LOG) go test $(TEST) -v -count 1 -timeout $(TIMEOUT)
 
 routeros: routeros-clean

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ lint: lint-client lint-provider
 
 test: lint testclient testacc
 
-testclient:
+testclient: wait-for-routeros
 	cd client; go test $(TEST) -race -v -count 1
 
-testacc:
+testacc: wait-for-routeros
 	TF_ACC=1 $(TF_LOG) go test $(TEST) -v -count 1 -timeout $(TIMEOUT)
 
 routeros: routeros-clean
@@ -57,3 +57,6 @@ routeros-logs:
 
 routeros-clean:
 	${compose} rm -sfv routeros
+
+wait-for-routeros:
+	${compose} run wait-for-routeros

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ testacc: wait-for-routeros
 	TF_ACC=1 $(TF_LOG) go test $(TEST) -v -count 1 -timeout $(TIMEOUT)
 
 routeros: routeros-clean
-	ROUTEROS_VERSION=$(ROUTEROS_VERSION) ${compose} up -d --build routeros
+	ROUTEROS_VERSION=$(ROUTEROS_VERSION) ${compose} up -d --build --remove-orphans routeros
 
 routeros-stop:
 	${compose} stop routeros
@@ -57,6 +57,3 @@ routeros-logs:
 
 routeros-clean:
 	${compose} rm -sfv routeros
-
-wait-for-routeros:
-	${compose} run wait-for-routeros

--- a/bin/wait-for-routeros.sh
+++ b/bin/wait-for-routeros.sh
@@ -1,16 +1,16 @@
 #!/bin/sh
 
 routeros_host=${1:-127.0.0.1}
-routeros_port=8728
+routeros_port=${2:-8080}
 
 echo "waiting for RouterOS (${routeros_host}:${routeros_port}) to be up and running"
-
 for i in $(seq 1 60); do
-    if nc -w1 ${routeros_host} ${routeros_port}; then
+    if curl -s --connect-timeout 1 -o /dev/null ${routeros_host}:${routeros_port}; then
         exit 0;
     else
         printf "."
         sleep 1
-    fi done;
+    fi
+done;
 
 exit 1

--- a/bin/wait-for-routeros.sh
+++ b/bin/wait-for-routeros.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+routeros_host=${1:-127.0.0.1}
+routeros_port=8728
+
+echo "waiting for RouterOS (${routeros_host}:${routeros_port}) to be up and running"
+
+for i in $(seq 1 60); do
+    if nc -w1 ${routeros_host} ${routeros_port}; then
+        exit 0;
+    else
+        printf "."
+        sleep 1
+    fi done;
+
+exit 1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,19 +16,3 @@ services:
     cap_add:
       - "NET_ADMIN"
     stop_grace_period: 20s
-
-  wait-for-routeros:
-    image: alpine
-    entrypoint: ["/bin/sh"]
-    command:
-      - "-c"
-      - >-
-        echo "waiting for RouterOS to be up and running";
-        for i in $(seq 1 60); do
-          if nc -w1 -z routeros 8728; then
-            exit 0;
-          else
-            printf ".";
-            sleep 1;
-          fi done;
-          exit 1

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,3 +16,19 @@ services:
     cap_add:
       - "NET_ADMIN"
     stop_grace_period: 20s
+
+  wait-for-routeros:
+    image: alpine
+    entrypoint: ["/bin/sh"]
+    command:
+      - "-c"
+      - >-
+        echo "waiting for RouterOS to be up and running";
+        for i in $(seq 1 60); do
+          if nc -w1 -z routeros 8728; then
+            exit 0;
+          else
+            printf ".";
+            sleep 1;
+          fi done;
+          exit 1


### PR DESCRIPTION
Sometimes, the `routeros` container is slow to start and `testclient`, `testacc` targets run against semi-working container.
This PR adds waiting logic.