### PR TITLE
improve client marshalling logic

### DIFF
--- a/client/bridge_vlan_test.go
+++ b/client/bridge_vlan_test.go
@@ -55,9 +55,11 @@ func TestBridgeVlanBasic(t *testing.T) {
 	}
 
 	expectedBridgeVlan := &BridgeVlan{
-		Id:      createdBridgeVlan.Id,
-		Bridge:  bridge1Name,
-		VlanIds: []int{10, 20},
+		Id:       createdBridgeVlan.Id,
+		Bridge:   bridge1Name,
+		VlanIds:  []int{10, 20},
+		Tagged:   []string{},
+		Untagged: []string{},
 	}
 	assert.Equal(t, expectedBridgeVlan, createdBridgeVlan)
 
@@ -66,9 +68,11 @@ func TestBridgeVlanBasic(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedBridgeVlan = &BridgeVlan{
-		Id:      createdBridgeVlan.Id,
-		Bridge:  bridge2Name,
-		VlanIds: []int{10, 20},
+		Id:       createdBridgeVlan.Id,
+		Bridge:   bridge2Name,
+		VlanIds:  []int{10, 20},
+		Tagged:   []string{},
+		Untagged: []string{},
 	}
 	assert.Equal(t, expectedBridgeVlan, updatedBridgeVlan)
 }

--- a/client/system_resources.go
+++ b/client/system_resources.go
@@ -7,8 +7,8 @@ import (
 )
 
 type SystemResources struct {
-	Uptime  types.MikrotikDuration `mikrotik:"uptime"`
-	Version string                 `mikrotik:"version"`
+	Uptime  types.MikrotikDuration `mikrotik:"uptime,readonly"`
+	Version string                 `mikrotik:"version,readonly"`
 }
 
 func (d *SystemResources) ActionToCommand(action Action) string {
@@ -27,6 +27,9 @@ func (client Mikrotik) GetSystemResources() (*SystemResources, error) {
 
 	log.Printf("[INFO] Running the mikrotik command: `%s`", cmd)
 	r, err := c.RunArgs(cmd)
+	if err != nil {
+		return nil, err
+	}
 
 	err = Unmarshal(*r, sysResources)
 	return sysResources, err

--- a/client/types/list.go
+++ b/client/types/list.go
@@ -16,6 +16,7 @@ func (m MikrotikList) MarshalMikrotik() string {
 
 func (m *MikrotikList) UnmarshalMikrotik(value string) error {
 	if len(value) == 0 {
+		*m = []string{}
 		return nil
 	}
 	*m = strings.Split(value, ",")
@@ -46,6 +47,7 @@ func (m MikrotikIntList) MarshalMikrotik() string {
 
 func (m *MikrotikIntList) UnmarshalMikrotik(value string) error {
 	if len(value) == 0 {
+		*m = []int{}
 		return nil
 	}
 	stringSlice := strings.Split(value, ",")

--- a/client/wireless_security_profile_test.go
+++ b/client/wireless_security_profile_test.go
@@ -19,8 +19,9 @@ func TestWirelessSecurityProfile_basic(t *testing.T) {
 
 	randSuffix := RandomString()
 	expected := &WirelessSecurityProfile{
-		Name: "test-profile-" + randSuffix,
-		Mode: WirelessModeNone,
+		Name:                "test-profile-" + randSuffix,
+		Mode:                WirelessModeNone,
+		AuthenticationTypes: []string{},
 	}
 
 	created, err := c.AddWirelessSecurityProfile(expected)

--- a/mikrotik/internal/utils/struct_copy.go
+++ b/mikrotik/internal/utils/struct_copy.go
@@ -122,7 +122,7 @@ func coreTypeToTerraformType(src, dest reflect.Value) error {
 		tfValue = tftypes.Float64Value(src.Float())
 	case reflect.Slice:
 		var diags diag.Diagnostics
-		var elements []interface{}
+		elements := []interface{}{}
 		for i := 0; i < src.Len(); i++ {
 			elements = append(elements, src.Index(i).Interface())
 		}


### PR DESCRIPTION
Changes introduced:
* if custom Mikrotik client type implements `Marshaler` interface, then give it the highest priority (previously, `Marshal` function checked value for `Zero`)
* if property is `readonly`, don't even try to marshal it
* list types produce empty slices rather than `nil` for empty values (improves handling changes in Terraform)